### PR TITLE
feat: integration test session management

### DIFF
--- a/src/test/java/com/example/echo_api/integration/IntegrationTest.java
+++ b/src/test/java/com/example/echo_api/integration/IntegrationTest.java
@@ -1,18 +1,20 @@
 package com.example.echo_api.integration;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.redis.testcontainers.RedisContainer;
-
-import jakarta.transaction.Transactional;
 
 @ActiveProfiles(value = "test")
 @Transactional
@@ -28,6 +30,12 @@ public abstract class IntegrationTest {
     @ServiceConnection
     protected static final RedisContainer redis = new RedisContainer("redis:latest");
 
+    @Autowired
+    private SessionCookieInterceptor restTemplateInterceptor;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
     static {
         redis.start();
 
@@ -36,12 +44,36 @@ public abstract class IntegrationTest {
         System.setProperty("spring.data.redis.port", redis.getMappedPort(6379).toString());
     }
 
+    /**
+     * Initialise the integration test environment by:
+     * <ul>
+     * <li>Configuring the {@link TestRestTemplate} with the
+     * {@link SessionCookieInterceptor}.</li>
+     * </ul>
+     */
+    @BeforeAll
+    public void init() {
+        // Configure rest template
+        restTemplate
+            .getRestTemplate()
+            .getInterceptors()
+            .add(restTemplateInterceptor);
+    }
+
+    /**
+     * Test ensures that the {@code postgres} container is initialised and running
+     * correctly.
+     */
     @Test
     public void postgresConnectionEstablished() {
         assertTrue(postgres.isCreated());
         assertTrue(postgres.isRunning());
     }
 
+    /**
+     * Test ensures that the {@code redis} container is initialised and running
+     * correctly.
+     */
     @Test
     public void redisConnectionEstablished() {
         assertTrue(redis.isCreated());

--- a/src/test/java/com/example/echo_api/integration/SessionCookieInterceptor.java
+++ b/src/test/java/com/example/echo_api/integration/SessionCookieInterceptor.java
@@ -1,0 +1,57 @@
+package com.example.echo_api.integration;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Intercepts HTTP requests and responses to manage session cookies for
+ * authentication as part of the application integration testing suite.
+ * 
+ * <p>
+ * If an authentication-related request is made as part of an integration test,
+ * the interceptor will bypass modification as to prevent failing tests that
+ * expect a fresh session cookie in the server response.
+ */
+@Component
+public class SessionCookieInterceptor implements ClientHttpRequestInterceptor {
+
+    private String sessionCookie;
+
+    @Override
+    @SuppressWarnings("null")
+    public ClientHttpResponse intercept(
+        @NonNull HttpRequest request,
+        @NonNull byte[] body,
+        @NonNull ClientHttpRequestExecution execution)
+        throws IOException {
+
+        // If authentication request, skip interception
+        if (request.getURI().getPath().contains("auth")) {
+            return execution.execute(request, body);
+        }
+
+        // Append session cookie to the request if present
+        if (sessionCookie != null) {
+            request.getHeaders().add(HttpHeaders.COOKIE, sessionCookie);
+        }
+
+        // Execute
+        ClientHttpResponse response = execution.execute(request, body);
+
+        // Capture session cookie from the response if present
+        String cookie = response.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+        if (cookie != null && cookie.startsWith("ECHO_SESSION")) {
+            sessionCookie = cookie;
+        }
+
+        return response;
+    }
+
+}

--- a/src/test/java/com/example/echo_api/integration/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/echo_api/integration/controller/AuthControllerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpStatus.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpEntity;
@@ -23,7 +22,6 @@ import com.example.echo_api.service.user.UserService;
 /**
  * Integration test class for {@link AuthController}.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AuthControllerTest extends IntegrationTest {
 

--- a/src/test/java/com/example/echo_api/integration/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/echo_api/integration/controller/AuthControllerTest.java
@@ -3,12 +3,10 @@ package com.example.echo_api.integration.controller;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpStatus.*;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 
@@ -30,29 +28,17 @@ import com.example.echo_api.service.user.UserService;
 class AuthControllerTest extends IntegrationTest {
 
     @Autowired
-    private TestRestTemplate restTemplate;
-
-    @Autowired
     private UserService userService;
-
-    private SignInRequest existingUser;
-
-    /**
-     * Set up test environment by initialising {@link SignInRequest} for
-     * {@code existingUser}, and registers {@code existingUser} to the database.
-     */
-    @BeforeAll
-    public void setUp() {
-        existingUser = new SignInRequest("existing_user", "password-1");
-        userService.createUser(existingUser.username(), existingUser.password());
-    }
 
     @Test
     void AuthController_SignIn_Return204() {
         // api: POST /api/v1/auth/login ==> 204 : No Content
         String endpoint = ApiConfig.Auth.LOGIN;
 
-        HttpEntity<SignInRequest> request = TestUtils.createJsonRequestEntity(existingUser);
+        // POST a login for the pre-existing testUser
+        SignInRequest loginForm = new SignInRequest(testUser.getUsername(), testUser.getPassword());
+
+        HttpEntity<SignInRequest> request = TestUtils.createJsonRequestEntity(loginForm);
         ResponseEntity<Void> response = restTemplate.postForEntity(endpoint, request, Void.class);
 
         // assert the response
@@ -65,9 +51,11 @@ class AuthControllerTest extends IntegrationTest {
     void AuthController_SignUp_Return204() throws Exception {
         // api: POST /api/v1/auth/signup ==> 204 : No Content
         String endpoint = ApiConfig.Auth.SIGNUP;
-        SignUpRequest newUser = new SignUpRequest("new_user", "password-1");
 
-        HttpEntity<SignUpRequest> request = TestUtils.createJsonRequestEntity(newUser);
+        // POST a signup for a new user
+        SignUpRequest signupForm = new SignUpRequest("new_user", "password1");
+
+        HttpEntity<SignUpRequest> request = TestUtils.createJsonRequestEntity(signupForm);
         ResponseEntity<Void> response = restTemplate.postForEntity(endpoint, request, Void.class);
 
         // assert response
@@ -76,18 +64,20 @@ class AuthControllerTest extends IntegrationTest {
         TestUtils.assertSetCookieStartsWith(response, "ECHO_SESSION");
 
         // assert db
-        User registeredUser = userService.findByUsername(newUser.username());
+        User registeredUser = userService.findByUsername(signupForm.username());
         assertNotNull(registeredUser);
-        assertEquals(newUser.username(), registeredUser.getUsername());
+        assertEquals(signupForm.username(), registeredUser.getUsername());
     }
 
     @Test
     void AuthController_SignUp_Return400UsernameAlreadyExists() {
         // api: POST /api/v1/auth/signup ==> 400 : Username Already Exists
         String endpoint = ApiConfig.Auth.SIGNUP;
-        SignUpRequest takenUser = new SignUpRequest(existingUser.username(), existingUser.password());
 
-        HttpEntity<SignUpRequest> request = TestUtils.createJsonRequestEntity(takenUser);
+        // POST a signup for the pre-existing testUser
+        SignUpRequest signupForm = new SignUpRequest(testUser.getUsername(), testUser.getPassword());
+
+        HttpEntity<SignUpRequest> request = TestUtils.createJsonRequestEntity(signupForm);
         ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(endpoint, request, ErrorResponse.class);
 
         // assert response

--- a/src/test/java/com/example/echo_api/integration/repository/RepositoryTest.java
+++ b/src/test/java/com/example/echo_api/integration/repository/RepositoryTest.java
@@ -1,0 +1,38 @@
+package com.example.echo_api.integration.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.example.echo_api.persistence.model.User;
+
+@ActiveProfiles(value = "test")
+@Transactional
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class RepositoryTest {
+
+    @Container
+    @ServiceConnection
+    protected static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:latest");
+
+    protected User testUser;
+
+    /**
+     * Test ensures that the {@code postgres} container is initialised and running
+     * correctly.
+     */
+    @Test
+    public void postgresConnectionEstablished() {
+        assertTrue(postgres.isCreated());
+        assertTrue(postgres.isRunning());
+    }
+
+}

--- a/src/test/java/com/example/echo_api/integration/repository/UserRepositoryTest.java
+++ b/src/test/java/com/example/echo_api/integration/repository/UserRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import com.example.echo_api.integration.IntegrationTest;
 import com.example.echo_api.persistence.model.User;
 import com.example.echo_api.persistence.repository.UserRepository;
 
@@ -17,19 +16,17 @@ import com.example.echo_api.persistence.repository.UserRepository;
  * Integration test class for {@link UserRepository}.
  */
 @DataJpaTest
-class UserRepositoryTest extends IntegrationTest {
+class UserRepositoryTest extends RepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    private User testUser;
 
     /**
      * Saves a {@link User} object to the {@link UserRepository} before each test.
      */
     @BeforeEach
     public void setUp() {
-        testUser = new User("test", "123");
+        testUser = new User("test", "password1");
         userRepository.save(testUser);
     }
 


### PR DESCRIPTION
### Purpose
PR introduces session management for integration testing the API

### Changes
- Add custom `SessionCookieInterceptor` that stores session cookie in memory and attaches to subsequent requests
- Implement a private method to pre-register and authenticate a test user within `IntegrationTest` for straight-forward testing of authenticated endpoints
- Implement a separate abstract `RepositoryTest` class for integration testing the repository layer. The repository layer tests should have a narrow application scope that focus solely on the JPA layer (via. `@DataJpaTest`).