### PR TITLE
feat: profile metrics

### DIFF
--- a/src/main/java/com/example/echo_api/config/ErrorMessageConfig.java
+++ b/src/main/java/com/example/echo_api/config/ErrorMessageConfig.java
@@ -15,6 +15,8 @@ public final class ErrorMessageConfig {
     public static final String INVALID_REQUEST = "Invalid request.";
     /* Auth */
     public static final String USERNAME_OR_PASSWORD_IS_INCORRECT = "Username or password is incorrect.";
+    /* Account */
+    public static final String ID_NOT_FOUND = "ID not found.";
     /* Username */
     public static final String USERNAME_NOT_FOUND = "Username not found.";
     public static final String USERNAME_ARLEADY_EXISTS = "Username already exists.";

--- a/src/main/java/com/example/echo_api/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/echo_api/exception/GlobalControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.example.echo_api.config.ErrorMessageConfig;
+import com.example.echo_api.exception.custom.account.AccountException;
 import com.example.echo_api.exception.custom.password.PasswordException;
 import com.example.echo_api.exception.custom.username.UsernameException;
 import com.example.echo_api.persistence.dto.response.error.ErrorDTO;
@@ -86,9 +87,9 @@ public class GlobalControllerAdvice extends AbstractControllerAdvice {
             msg);
     }
 
-    /* Username/Password Exception */
-    @ExceptionHandler({ UsernameException.class, PasswordException.class })
-    ResponseEntity<ErrorDTO> handleUsernamePasswordException(HttpServletRequest request, Exception ex) {
+    /* Custom Bad Request Exception */
+    @ExceptionHandler({ AccountException.class, UsernameException.class, PasswordException.class })
+    ResponseEntity<ErrorDTO> handleCustomBadRequestException(HttpServletRequest request, Exception ex) {
         log.debug("Handling exception: {}", ex.getMessage());
 
         return createExceptionHandler(

--- a/src/main/java/com/example/echo_api/exception/custom/account/AccountException.java
+++ b/src/main/java/com/example/echo_api/exception/custom/account/AccountException.java
@@ -1,0 +1,19 @@
+package com.example.echo_api.exception.custom.account;
+
+/**
+ * Abstract superclass for all exceptions related to a {@link Account} object
+ * being invalid for whatever reason.
+ */
+public abstract class AccountException extends RuntimeException {
+
+    /**
+     * Constructs a {@code AccountException} with the specified message and no root
+     * cause.
+     * 
+     * @param msg The detail message.
+     */
+    protected AccountException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/example/echo_api/exception/custom/account/IdNotFoundException.java
+++ b/src/main/java/com/example/echo_api/exception/custom/account/IdNotFoundException.java
@@ -1,0 +1,18 @@
+package com.example.echo_api.exception.custom.account;
+
+import com.example.echo_api.config.ErrorMessageConfig;
+
+/**
+ * Thrown if a HTTP request is rejected because the supplied id does not exist
+ * in the db.
+ */
+public class IdNotFoundException extends AccountException {
+
+    /**
+     * Constructs a {@code IdNotFoundException} with the specified message.
+     */
+    public IdNotFoundException() {
+        super(ErrorMessageConfig.ID_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/example/echo_api/exception/custom/password/PasswordException.java
+++ b/src/main/java/com/example/echo_api/exception/custom/password/PasswordException.java
@@ -10,7 +10,7 @@ public abstract class PasswordException extends RuntimeException {
      * Constructs a {@code PasswordException} with the specified message and no root
      * cause.
      * 
-     * @param msg the detail message
+     * @param msg The detail message.
      */
     protected PasswordException(String msg) {
         super(msg);

--- a/src/main/java/com/example/echo_api/exception/custom/username/UsernameException.java
+++ b/src/main/java/com/example/echo_api/exception/custom/username/UsernameException.java
@@ -7,10 +7,10 @@ package com.example.echo_api.exception.custom.username;
 public abstract class UsernameException extends RuntimeException {
 
     /**
-     * Constructs a {@code PasswordException} with the specified message and no root
+     * Constructs a {@code UsernameException} with the specified message and no root
      * cause.
      * 
-     * @param msg the detail message
+     * @param msg The detail message.
      */
     protected UsernameException(String msg) {
         super(msg);

--- a/src/main/java/com/example/echo_api/persistence/dto/response/profile/MetricsDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/profile/MetricsDTO.java
@@ -2,6 +2,14 @@ package com.example.echo_api.persistence.dto.response.profile;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Represents a standardised response format for profile {@link Metrics}.
+ *
+ * @param followingCount The number of profiles this profile is following.
+ * @param followerCount  The number of followers this profile has.
+ * @param postCount      The number of posts this profile has made.
+ * @param mediaCount     The number of media items this profile has uploaded.
+ */
 // @formatter:off
 public record MetricsDTO(
     @JsonProperty("following_count") int followingCount,

--- a/src/main/java/com/example/echo_api/persistence/dto/response/profile/MetricsDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/profile/MetricsDTO.java
@@ -1,0 +1,12 @@
+package com.example.echo_api.persistence.dto.response.profile;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// @formatter:off
+public record MetricsDTO(
+    @JsonProperty("following_count") int followingCount,
+    @JsonProperty("follower_count") int followerCount,
+    @JsonProperty("post_count") int postCount,
+    @JsonProperty("media_count") int mediaCount
+) {}
+// @formatter:on

--- a/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
@@ -28,7 +28,8 @@ public record ProfileDTO(
     String location,
     @JsonProperty("avatar_url") String avatarUrl,
     @JsonProperty("banner_url") String bannerUrl,
-    @JsonProperty("created_at") String createdAt
+    @JsonProperty("created_at") String createdAt,
+    @JsonProperty("profile_metrics") MetricsDTO metrics
 ) {
 
     public ProfileDTO(
@@ -38,7 +39,8 @@ public record ProfileDTO(
         String location,
         String avatarUrl,
         String bannerUrl,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        MetricsDTO metrics
     ) {
         this(
             username,
@@ -47,7 +49,8 @@ public record ProfileDTO(
             location,
             avatarUrl,
             bannerUrl,
-            createdAt != null ? createdAt.toString() : null
+            createdAt != null ? createdAt.toString() : null,
+            metrics
         );
     }
 

--- a/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
@@ -28,10 +28,6 @@ public record ProfileDTO(
     String location,
     @JsonProperty("avatar_url") String avatarUrl,
     @JsonProperty("banner_url") String bannerUrl,
-    @JsonProperty("following_count") int followingCount,
-    @JsonProperty("follower_count") int followerCount,
-    @JsonProperty("post_count") int postCount,
-    @JsonProperty("media_count") int mediaCount,
     @JsonProperty("created_at") String createdAt
 ) {
 
@@ -42,10 +38,6 @@ public record ProfileDTO(
         String location,
         String avatarUrl,
         String bannerUrl,
-        int followingCount,
-        int followerCount,
-        int postCount,
-        int mediaCount,
         LocalDateTime createdAt
     ) {
         this(
@@ -55,10 +47,6 @@ public record ProfileDTO(
             location,
             avatarUrl,
             bannerUrl,
-            followingCount,
-            followerCount,
-            postCount,
-            mediaCount,
             createdAt != null ? createdAt.toString() : null
         );
     }

--- a/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/profile/ProfileDTO.java
@@ -7,18 +7,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Represents a standardised response format for an {@link Account} profile.
  *
- * @param username       The username of the account associated to the profile.
- * @param name           The profile name.
- * @param bio            The profile bio.
- * @param location       The profile location.
- * @param avatarUrl      The URL of the profile avatar image.
- * @param bannerUrl      The URL of the profile banner image.
- * @param followingCount The number of profiles this profile is following.
- * @param followerCount  The number of followers this profile has.
- * @param postCount      The number of posts this profile has made.
- * @param mediaCount     The number of media items this profile has uploaded.
- * @param createdAt      The timestamp when the profile was created (ISO-8601
- *                       format).
+ * @param username  The username of the account associated to the profile.
+ * @param name      The profile name.
+ * @param bio       The profile bio.
+ * @param location  The profile location.
+ * @param avatarUrl The URL of the profile avatar image.
+ * @param bannerUrl The URL of the profile banner image.
+ * @param createdAt The timestamp when the profile was created (ISO-8601
+ *                  format).
+ * @param metrics   The profile metrics.
  */
 // @formatter:off
 public record ProfileDTO(

--- a/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
@@ -3,7 +3,9 @@ package com.example.echo_api.persistence.mapper;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.profile.MetricsDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
+import com.example.echo_api.persistence.model.profile.Metrics;
 import com.example.echo_api.persistence.model.profile.Profile;
 
 import lombok.NoArgsConstructor;
@@ -11,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public class ProfileMapper {
 
-    public static ProfileDTO toDTO(Profile profile) {
+    public static ProfileDTO toDTO(Profile profile, Metrics metrics) {
         return new ProfileDTO(
             profile.getUsername(),
             profile.getName(),
@@ -19,7 +21,16 @@ public class ProfileMapper {
             profile.getLocation(),
             profile.getAvatarUrl(),
             profile.getBannerUrl(),
-            profile.getCreatedAt());
+            profile.getCreatedAt(),
+            toMetricsDTO(metrics));
+    }
+
+    private static MetricsDTO toMetricsDTO(Metrics metrics) {
+        return new MetricsDTO(
+            metrics.getFollowingCount(),
+            metrics.getFollowerCount(),
+            metrics.getPostCount(),
+            metrics.getMediaCount());
     }
 
     public static Profile updateProfile(UpdateProfileDTO request, Profile profile) {

--- a/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public class ProfileMapper {
 
-    public static ProfileDTO toResponse(Profile profile) {
+    public static ProfileDTO toDTO(Profile profile) {
         return new ProfileDTO(
             profile.getUsername(),
             profile.getName(),

--- a/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
@@ -19,10 +19,6 @@ public class ProfileMapper {
             profile.getLocation(),
             profile.getAvatarUrl(),
             profile.getBannerUrl(),
-            profile.getFollowingCount(),
-            profile.getFollowingCount(),
-            profile.getPostCount(),
-            profile.getMediaCount(),
             profile.getCreatedAt());
     }
 

--- a/src/main/java/com/example/echo_api/persistence/model/profile/Metrics.java
+++ b/src/main/java/com/example/echo_api/persistence/model/profile/Metrics.java
@@ -60,11 +60,11 @@ public class Metrics {
 
     // ---- incrementers ----
 
-    public void incrementFollowing() {
+    public void incrementFollowingCount() {
         this.followingCount++;
     }
 
-    public void incrementFollowers() {
+    public void incrementFollowerCount() {
         this.followerCount++;
     }
 
@@ -78,11 +78,11 @@ public class Metrics {
 
     // ---- decrementers ----
 
-    public void decrementFollowing() {
+    public void decrementFollowingCount() {
         this.followingCount--;
     }
 
-    public void decrementFollowers() {
+    public void decrementFollowerCount() {
         this.followerCount--;
     }
 

--- a/src/main/java/com/example/echo_api/persistence/model/profile/Metrics.java
+++ b/src/main/java/com/example/echo_api/persistence/model/profile/Metrics.java
@@ -1,0 +1,97 @@
+package com.example.echo_api.persistence.model.profile;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.example.echo_api.persistence.model.account.Account;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entity class representing a {@link Account} profile in the system.
+ */
+@Entity
+@Table(name = "profile_metrics")
+@Getter
+@NoArgsConstructor
+public class Metrics {
+
+    // ---- primary keys / foreign keys ----
+
+    @Id
+    @Column(name = "profile_id", unique = true, nullable = false)
+    private UUID profileId; // PK, FK
+
+    // ---- entity-specific attributes ----
+
+    @Column(name = "following_count")
+    private int followingCount = 0;
+
+    @Column(name = "follower_count")
+    private int followerCount = 0;
+
+    @Column(name = "post_count")
+    private int postCount = 0;
+
+    @Column(name = "media_count")
+    private int mediaCount = 0;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // ---- constructors ----
+
+    public Metrics(Profile profile) {
+        this.profileId = profile.getProfileId();
+    }
+
+    // ---- incrementers ----
+
+    public void incrementFollowing() {
+        this.followingCount++;
+    }
+
+    public void incrementFollowers() {
+        this.followerCount++;
+    }
+
+    public void incrementPostCount() {
+        this.postCount++;
+    }
+
+    public void incrementMediaCount() {
+        this.mediaCount++;
+    }
+
+    // ---- decrementers ----
+
+    public void decrementFollowing() {
+        this.followingCount--;
+    }
+
+    public void decrementFollowers() {
+        this.followerCount--;
+    }
+
+    public void decrementPostCount() {
+        this.postCount--;
+    }
+
+    public void decrementMediaCount() {
+        this.mediaCount--;
+    }
+
+}

--- a/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
+++ b/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * Entity class representing a {@link Account} profile in the system.
+ * Entity class representing an {@link Account} profile in the system.
  */
 @Entity
 @Table
@@ -28,8 +28,8 @@ public class Profile {
     // ---- primary keys / foreign keys ----
 
     @Id
-    @Column(name = "account_id", unique = true, nullable = false)
-    private UUID accountId; // PK, FK
+    @Column(name = "profile_id", unique = true, nullable = false)
+    private UUID profileId; // PK, FK
 
     @Username
     @Column(unique = true, nullable = false)
@@ -49,18 +49,6 @@ public class Profile {
     @Column(name = "banner_url")
     private String bannerUrl;
 
-    @Column(name = "following_count")
-    private int followingCount = 0;
-
-    @Column(name = "follower_count")
-    private int followerCount = 0;
-
-    @Column(name = "post_count")
-    private int postCount = 0;
-
-    @Column(name = "media_count")
-    private int mediaCount = 0;
-
     @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -72,7 +60,7 @@ public class Profile {
     // ---- constructors ----
 
     public Profile(Account account) {
-        this.accountId = account.getId();
+        this.profileId = account.getId();
         this.username = account.getUsername();
     }
 
@@ -96,42 +84,6 @@ public class Profile {
 
     public void setBannerUrl(String bannerUrl) {
         this.bannerUrl = bannerUrl;
-    }
-
-    // ---- incrementers ----
-
-    public void incrementFollowing() {
-        this.followingCount++;
-    }
-
-    public void incrementFollowers() {
-        this.followerCount++;
-    }
-
-    public void incrementPostCount() {
-        this.postCount++;
-    }
-
-    public void incrementMediaCount() {
-        this.mediaCount++;
-    }
-
-    // ---- decrementers ----
-
-    public void decrementFollowing() {
-        this.followingCount--;
-    }
-
-    public void decrementFollowers() {
-        this.followerCount--;
-    }
-
-    public void decrementPostCount() {
-        this.postCount--;
-    }
-
-    public void decrementMediaCount() {
-        this.mediaCount--;
     }
 
 }

--- a/src/main/java/com/example/echo_api/persistence/repository/MetricsRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/MetricsRepository.java
@@ -1,0 +1,11 @@
+package com.example.echo_api.persistence.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.repository.ListCrudRepository;
+
+import com.example.echo_api.persistence.model.profile.Metrics;
+
+public interface MetricsRepository extends ListCrudRepository<Metrics, UUID> {
+
+}

--- a/src/main/java/com/example/echo_api/service/account/AccountService.java
+++ b/src/main/java/com/example/echo_api/service/account/AccountService.java
@@ -13,6 +13,11 @@ public interface AccountService {
      * Registers a new {@link Account} with the specified {@code username} and
      * {@code password}.
      * 
+     * <p>
+     * If the username is available, it creates an {@link Account} object, and
+     * associated {@link Profile} object, and an associated profile {@link Metrics}
+     * object.
+     * 
      * @param username The username of the account to register.
      * @param password The password of the account to register.
      * @return The newly registered {@link Account}.
@@ -28,7 +33,6 @@ public interface AccountService {
      * If the username is available, it creates an {@link Account} object, and
      * associated {@link Profile} object, and an associated profile {@link Metrics}
      * object.
-     * 
      * 
      * @param username The username of the account to register.
      * @param password The password of the account to register.

--- a/src/main/java/com/example/echo_api/service/account/AccountService.java
+++ b/src/main/java/com/example/echo_api/service/account/AccountService.java
@@ -4,12 +4,14 @@ import com.example.echo_api.exception.custom.password.IncorrectCurrentPasswordEx
 import com.example.echo_api.exception.custom.username.UsernameAlreadyExistsException;
 import com.example.echo_api.persistence.model.account.Role;
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
+import com.example.echo_api.persistence.model.profile.Profile;
 
 public interface AccountService {
 
     /**
-     * Creates a new {@link Account} within the application, using the standard
-     * {@link Role}, {@code Role.USER}.
+     * Registers a new {@link Account} with the specified {@code username} and
+     * {@code password}.
      * 
      * @param username The username of the account to register.
      * @param password The password of the account to register.
@@ -19,12 +21,19 @@ public interface AccountService {
     public Account register(String username, String password) throws UsernameAlreadyExistsException;
 
     /**
-     * Creates a new {@link Account} within the application, using the supplied
-     * {@link Role}.
+     * Registers a new {@link Account} with the specified {@code username},
+     * {@code password} and {@code role}.
+     * 
+     * <p>
+     * If the username is available, it creates an {@link Account} object, and
+     * associated {@link Profile} object, and an associated profile {@link Metrics}
+     * object.
+     * 
      * 
      * @param username The username of the account to register.
      * @param password The password of the account to register.
-     * @return The newly registered {@link Account}.
+     * @param role     The role to assign to the new account.
+     * @return The created {@link Account} object.
      * @throws UsernameAlreadyExistsException If the username is already taken.
      */
     public Account registerWithRole(String username, String password, Role role) throws UsernameAlreadyExistsException;

--- a/src/main/java/com/example/echo_api/service/account/AccountServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/account/AccountServiceImpl.java
@@ -6,8 +6,12 @@ import org.springframework.stereotype.Service;
 import com.example.echo_api.exception.custom.password.IncorrectCurrentPasswordException;
 import com.example.echo_api.exception.custom.username.UsernameAlreadyExistsException;
 import com.example.echo_api.persistence.model.account.Role;
+import com.example.echo_api.persistence.model.profile.Metrics;
+import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.repository.AccountRepository;
+import com.example.echo_api.persistence.repository.MetricsRepository;
+import com.example.echo_api.persistence.repository.ProfileRepository;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.service.session.SessionService;
 
@@ -25,10 +29,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AccountServiceImpl implements AccountService {
 
-    private final ProfileService profileService;
     private final SessionService sessionService;
 
     private final AccountRepository accountRepository;
+    private final ProfileRepository profileRepository;
+    private final MetricsRepository metricsRepository;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -45,7 +50,12 @@ public class AccountServiceImpl implements AccountService {
 
         Account account = new Account(username, passwordEncoder.encode(password), role);
         accountRepository.save(account);
-        profileService.registerForAccount(account);
+
+        Profile profile = new Profile(account);
+        profileRepository.save(profile);
+
+        Metrics metrics = new Metrics(profile);
+        metricsRepository.save(metrics);
 
         return account;
     }

--- a/src/main/java/com/example/echo_api/service/metrics/MetricsService.java
+++ b/src/main/java/com/example/echo_api/service/metrics/MetricsService.java
@@ -10,10 +10,74 @@ public interface MetricsService {
     /**
      * Fetches profile {@link Metrics} via {@code profile_id}.
      * 
-     * @param profileId The profile id.
+     * @param profileId The profile id of the metrics to fetch.
      * @return profile {@link Metrics}.
      * @throws IdNotFoundException If the id is not found.
      */
     public Metrics getMetrics(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by incrementing {@code followingCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void incrementFollowing(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by incrementing {@code followerCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void incrementFollowers(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by incrementing {@code postCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void incrementPosts(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by incrementing {@code mediaCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void incrementMedia(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by decrementing {@code followingCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void decrementFollowing(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by decrementing {@code followerCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void decrementFollowers(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by decrementing {@code postCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void decrementPosts(UUID profileId) throws IdNotFoundException;
+
+    /**
+     * Updates profile {@link Metrics} by decrementing {@code mediaCount}.
+     * 
+     * @param profileId The profile id of the metrics to update.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public void decrementMedia(UUID profileId) throws IdNotFoundException;
 
 }

--- a/src/main/java/com/example/echo_api/service/metrics/MetricsService.java
+++ b/src/main/java/com/example/echo_api/service/metrics/MetricsService.java
@@ -1,0 +1,19 @@
+package com.example.echo_api.service.metrics;
+
+import java.util.UUID;
+
+import com.example.echo_api.exception.custom.account.IdNotFoundException;
+import com.example.echo_api.persistence.model.profile.Metrics;
+
+public interface MetricsService {
+
+    /**
+     * Fetches profile {@link Metrics} via {@code profile_id}.
+     * 
+     * @param profileId The profile id.
+     * @return profile {@link Metrics}.
+     * @throws IdNotFoundException If the id is not found.
+     */
+    public Metrics getMetrics(UUID profileId) throws IdNotFoundException;
+
+}

--- a/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.echo_api.service.metrics;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.example.echo_api.exception.custom.account.IdNotFoundException;
+import com.example.echo_api.persistence.model.profile.Metrics;
+import com.example.echo_api.persistence.repository.MetricsRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service implementation for managing CRUD operations of profile
+ * {@link Metrics}.
+ * 
+ * @see MetricsRepository
+ */
+@Service
+@RequiredArgsConstructor
+public class MetricsServiceImpl implements MetricsService {
+
+    private MetricsRepository metricsRepository;
+
+    @Override
+    public Metrics getMetrics(UUID profileId) throws IdNotFoundException {
+        return findById(profileId);
+    }
+
+    /**
+     * Internal method for obtaining {@link Metrics} via {@code profile_id} from
+     * {@link MetricsRepository}.
+     * 
+     * @param id The profileId to search within the repository.
+     * @return The found {@link Metrics}.
+     */
+    private Metrics findById(UUID id) throws IdNotFoundException {
+        return metricsRepository.findById(id)
+            .orElseThrow(IdNotFoundException::new);
+    }
+
+}

--- a/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
@@ -27,6 +27,62 @@ public class MetricsServiceImpl implements MetricsService {
         return findById(profileId);
     }
 
+    @Override
+    public void incrementFollowing(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.incrementFollowingCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void incrementFollowers(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.incrementFollowerCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void incrementPosts(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.incrementPostCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void incrementMedia(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.incrementMediaCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void decrementFollowing(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.decrementFollowingCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void decrementFollowers(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.decrementFollowerCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void decrementPosts(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.decrementPostCount();
+        metricsRepository.save(metrics);
+    }
+
+    @Override
+    public void decrementMedia(UUID profileId) throws IdNotFoundException {
+        Metrics metrics = findById(profileId);
+        metrics.decrementMediaCount();
+        metricsRepository.save(metrics);
+    }
+
     /**
      * Internal method for obtaining {@link Metrics} via {@code profile_id} from
      * {@link MetricsRepository}.

--- a/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/metrics/MetricsServiceImpl.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MetricsServiceImpl implements MetricsService {
 
-    private MetricsRepository metricsRepository;
+    private final MetricsRepository metricsRepository;
 
     @Override
     public Metrics getMetrics(UUID profileId) throws IdNotFoundException {

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -3,19 +3,9 @@ package com.example.echo_api.service.profile;
 import com.example.echo_api.exception.custom.username.UsernameException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
-import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.model.profile.Profile;
 
 public interface ProfileService {
-
-    /**
-     * Creates a profile for a newly registered {@link Account} with a 1-to-1
-     * relationship. The method is consumed by {@link AccountService}.
-     * 
-     * @param account The account for whom the profile is to be created.
-     * @return The created {@link Profile}.
-     */
-    public Profile registerForAccount(Account account);
 
     /**
      * Fetch a {@link Profile} by username to return to the client.

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -8,8 +8,10 @@ import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.repository.ProfileRepository;
+import com.example.echo_api.service.metrics.MetricsService;
 import com.example.echo_api.service.session.SessionService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
  * Service implementation for managing CRUD operations of a {@link Profile}.
  * 
  * @see SessionService
+ * @see MetricsService
  * @see ProfileRepository
  */
 @Service
@@ -25,19 +28,22 @@ import lombok.RequiredArgsConstructor;
 public class ProfileServiceImpl implements ProfileService {
 
     private final SessionService sessionService;
+    private final MetricsService metricsService;
 
     private final ProfileRepository profileRepository;
 
     @Override
     public ProfileDTO getByUsername(String username) throws UsernameException {
         Profile profile = findByUsername(username);
-        return ProfileMapper.toDTO(profile);
+        Metrics metrics = metricsService.getMetrics(profile.getProfileId());
+        return ProfileMapper.toDTO(profile, metrics);
     }
 
     @Override
     public ProfileDTO getMe() {
         Profile me = findMe();
-        return ProfileMapper.toDTO(me);
+        Metrics metrics = metricsService.getMetrics(me.getProfileId());
+        return ProfileMapper.toDTO(me, metrics);
     }
 
     @Override

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -29,12 +29,6 @@ public class ProfileServiceImpl implements ProfileService {
     private final ProfileRepository profileRepository;
 
     @Override
-    public Profile registerForAccount(Account account) {
-        Profile profile = new Profile(account);
-        return profileRepository.save(profile);
-    }
-
-    @Override
     public ProfileDTO getByUsername(String username) throws UsernameException {
         Profile profile = findByUsername(username);
         return ProfileMapper.toResponse(profile);

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -31,13 +31,13 @@ public class ProfileServiceImpl implements ProfileService {
     @Override
     public ProfileDTO getByUsername(String username) throws UsernameException {
         Profile profile = findByUsername(username);
-        return ProfileMapper.toResponse(profile);
+        return ProfileMapper.toDTO(profile);
     }
 
     @Override
     public ProfileDTO getMe() {
         Profile me = findMe();
-        return ProfileMapper.toResponse(me);
+        return ProfileMapper.toDTO(me);
     }
 
     @Override

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,23 +15,31 @@ CREATE UNIQUE INDEX
     
 CREATE TABLE
     IF NOT EXISTS "profile" (
-        account_id       UUID PRIMARY KEY UNIQUE NOT NULL,
+        profile_id       UUID PRIMARY KEY UNIQUE NOT NULL,
         username         VARCHAR(15) UNIQUE NOT NULL CHECK (username ~ '^[a-zA-Z0-9_]{3,15}$'),
         name             VARCHAR(50),
         bio              VARCHAR(160),
         location         VARCHAR(30),
         avatar_url       VARCHAR(255),
         banner_url       VARCHAR(255),
-        following_count  INT NOT NULL DEFAULT 0,
-        follower_count   INT NOT NULL DEFAULT 0,
-        post_count       INT NOT NULL DEFAULT 0,
-        media_count      INT NOT NULL DEFAULT 0,
         created_at       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT fk_account_id FOREIGN KEY (account_id) REFERENCES "account"(id) ON DELETE CASCADE,
+        CONSTRAINT fk_profile_id FOREIGN KEY (profile_id) REFERENCES "account"(id) ON DELETE CASCADE,
         CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES "account"(username) ON UPDATE CASCADE
     );
 
 CREATE UNIQUE INDEX 
     IF NOT EXISTS idx_profile_username
         ON "profile"(Lower(username));
+
+CREATE TABLE
+    IF NOT EXISTS "profile_metrics" (
+        profile_id       UUID PRIMARY KEY UNIQUE NOT NULL,
+        following_count  INT NOT NULL DEFAULT 0,
+        follower_count   INT NOT NULL DEFAULT 0,
+        post_count       INT NOT NULL DEFAULT 0,
+        media_count      INT NOT NULL DEFAULT 0,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT fk_profile_id FOREIGN KEY (profile_id) REFERENCES "profile"(profile_id) ON DELETE CASCADE
+    );

--- a/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
+++ b/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
@@ -25,8 +25,8 @@ import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 class ProfileControllerIT extends IntegrationTest {
 
     @Test
-    void ProfileController_GetMe_ReturnProfileResponse() {
-        // api: GET /api/v1/profile/me ==> 200 : ProfileResponse
+    void ProfileController_GetMe_ReturnProfileDTO() {
+        // api: GET /api/v1/profile/me ==> 200 : ProfileDTO
         String path = ApiConfig.Profile.GET_ME;
 
         ResponseEntity<ProfileDTO> response = restTemplate.getForEntity(path, ProfileDTO.class);
@@ -60,8 +60,8 @@ class ProfileControllerIT extends IntegrationTest {
     }
 
     @Test
-    void ProfileController_GetByUsername_ReturnProfileResponse() {
-        // api: GET /api/v1/profile/{username} ==> 200 : ProfileResponse
+    void ProfileController_GetByUsername_ReturnProfileDTO() {
+        // api: GET /api/v1/profile/{username} ==> 200 : ProfileDTO
         String path = ApiConfig.Profile.GET_BY_USERNAME;
 
         ResponseEntity<ProfileDTO> response = restTemplate.getForEntity(

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
@@ -51,7 +51,7 @@ class ProfileControllerTest {
 
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toResponse(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile);
 
         when(profileService.getMe()).thenReturn(expected);
 
@@ -234,7 +234,7 @@ class ProfileControllerTest {
 
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toResponse(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile);
 
         when(profileService.getByUsername(expected.username())).thenReturn(expected);
 

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
@@ -24,6 +24,7 @@ import com.example.echo_api.persistence.dto.response.error.ErrorDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.service.profile.ProfileService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,13 +46,14 @@ class ProfileControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
-    void ProfileController_GetMe_ReturnProfileResponse() throws Exception {
+    void ProfileController_GetMe_ReturnProfileDTO() throws Exception {
         // api: GET /api/v1/profile/me ==> 200 : ProfileResponse
         String path = ApiConfig.Profile.GET_ME;
 
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toDTO(profile);
+        Metrics metrics = new Metrics(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics);
 
         when(profileService.getMe()).thenReturn(expected);
 
@@ -228,13 +230,14 @@ class ProfileControllerTest {
     }
 
     @Test
-    void ProfileController_GetByUsername_ReturnProfileResponse() throws Exception {
-        // api: GET /api/v1/profile/{username} ==> 200 : ProfileResponse
+    void ProfileController_GetByUsername_ReturnProfileDTO() throws Exception {
+        // api: GET /api/v1/profile/{username} ==> 200 : ProfileDTO
         String path = ApiConfig.Profile.GET_BY_USERNAME;
 
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toDTO(profile);
+        Metrics metrics = new Metrics(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics);
 
         when(profileService.getByUsername(expected.username())).thenReturn(expected);
 

--- a/src/test/java/com/example/echo_api/unit/mapper/ProfileMapperTest.java
+++ b/src/test/java/com/example/echo_api/unit/mapper/ProfileMapperTest.java
@@ -1,0 +1,52 @@
+package com.example.echo_api.unit.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
+import com.example.echo_api.persistence.mapper.ProfileMapper;
+import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
+import com.example.echo_api.persistence.model.profile.Profile;
+
+class ProfileMapperTest {
+
+    @Test
+    void ProfileMapper_toDTO() {
+        Account account = new Account("test", "test");
+        Profile profile = new Profile(account);
+        Metrics metrics = new Metrics(profile);
+
+        ProfileDTO response = ProfileMapper.toDTO(profile, metrics);
+
+        assertNotNull(response);
+        assertEquals(account.getUsername(), response.username());
+        assertEquals(profile.getName(), response.name());
+        assertEquals(profile.getBio(), response.bio());
+        assertEquals(profile.getLocation(), response.location());
+        assertEquals(profile.getAvatarUrl(), response.avatarUrl());
+        assertEquals(profile.getBannerUrl(), response.bannerUrl());
+        assertEquals(metrics.getFollowingCount(), response.metrics().followingCount());
+        assertEquals(metrics.getFollowerCount(), response.metrics().followerCount());
+        assertEquals(metrics.getPostCount(), response.metrics().postCount());
+        assertEquals(metrics.getMediaCount(), response.metrics().mediaCount());
+    }
+
+    @Test
+    void ProfileMapper_updateProfile() {
+        Account account = new Account("test", "test");
+        Profile profile = new Profile(account);
+        UpdateProfileDTO request = new UpdateProfileDTO("name", "bio", "location");
+
+        Profile updated = ProfileMapper.updateProfile(request, profile);
+
+        assertNotNull(updated);
+        assertEquals(request.name(), updated.getName());
+        assertEquals(request.location(), updated.getLocation());
+        assertEquals(request.bio(), updated.getBio());
+    }
+
+}

--- a/src/test/java/com/example/echo_api/unit/service/AccountServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/AccountServiceTest.java
@@ -17,6 +17,8 @@ import com.example.echo_api.exception.custom.username.UsernameAlreadyExistsExcep
 import com.example.echo_api.persistence.dto.request.account.UpdatePasswordDTO;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.repository.AccountRepository;
+import com.example.echo_api.persistence.repository.MetricsRepository;
+import com.example.echo_api.persistence.repository.ProfileRepository;
 import com.example.echo_api.service.account.AccountService;
 import com.example.echo_api.service.account.AccountServiceImpl;
 import com.example.echo_api.service.session.SessionService;
@@ -32,6 +34,12 @@ class AccountServiceTest {
 
     @Mock
     private AccountRepository accountRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private MetricsRepository metricsRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -55,16 +63,17 @@ class AccountServiceTest {
      * exist.
      */
     @Test
-    void accountService_Register_ReturnVoid() {
+    void accountService_Register_ReturnAccount() {
         // arrange
         when(accountRepository.save(account)).thenReturn(account);
         when(accountRepository.existsByUsername(account.getUsername())).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
 
         // act
-        accountService.register(account.getUsername(), account.getPassword());
+        Account registered = accountService.register(account.getUsername(), account.getPassword());
 
         // assert
+        assertEquals(account, registered);
         verify(accountRepository, times(1)).save(account);
         verify(passwordEncoder, times(1)).encode(account.getPassword());
     }

--- a/src/test/java/com/example/echo_api/unit/service/AccountServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/AccountServiceTest.java
@@ -16,11 +16,9 @@ import com.example.echo_api.exception.custom.password.IncorrectCurrentPasswordEx
 import com.example.echo_api.exception.custom.username.UsernameAlreadyExistsException;
 import com.example.echo_api.persistence.dto.request.account.UpdatePasswordDTO;
 import com.example.echo_api.persistence.model.account.Account;
-import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.repository.AccountRepository;
 import com.example.echo_api.service.account.AccountService;
 import com.example.echo_api.service.account.AccountServiceImpl;
-import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.service.session.SessionService;
 
 /**
@@ -28,9 +26,6 @@ import com.example.echo_api.service.session.SessionService;
  */
 @ExtendWith(MockitoExtension.class)
 class AccountServiceTest {
-
-    @Mock
-    private ProfileService profileService;
 
     @Mock
     private SessionService sessionService;
@@ -63,7 +58,6 @@ class AccountServiceTest {
     void accountService_Register_ReturnVoid() {
         // arrange
         when(accountRepository.save(account)).thenReturn(account);
-        when(profileService.registerForAccount(account)).thenReturn(new Profile(account));
         when(accountRepository.existsByUsername(account.getUsername())).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
 

--- a/src/test/java/com/example/echo_api/unit/service/MetricsServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/MetricsServiceTest.java
@@ -1,0 +1,255 @@
+package com.example.echo_api.unit.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.echo_api.exception.custom.account.IdNotFoundException;
+import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
+import com.example.echo_api.persistence.model.profile.Profile;
+import com.example.echo_api.persistence.repository.MetricsRepository;
+import com.example.echo_api.service.metrics.MetricsServiceImpl;
+
+/**
+ * Unit test class for {@link MetricsServiceTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class MetricsServiceTest {
+
+    @Mock
+    private MetricsRepository metricsRepository;
+
+    @InjectMocks
+    private MetricsServiceImpl metricsService;
+
+    private static Metrics expected;
+
+    @BeforeAll
+    static void setup() {
+        Account account = new Account("test", "test");
+        Profile profile = new Profile(account);
+        expected = new Metrics(profile);
+    }
+
+    @Test
+    void MetricsService_GetMetrics_ReturnMetrics() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act
+        Metrics actual = metricsService.getMetrics(uuid);
+
+        // assert
+        assertNotNull(actual);
+        assertEquals(expected, actual);
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_GetMetrics_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.getMetrics(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+
+    }
+
+    // following
+
+    @Test
+    void MetricsService_IncrementFollowing_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.incrementFollowing(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_IncrementFollowing_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.incrementFollowing(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementFollowing_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.decrementFollowing(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementFollowing_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.decrementFollowing(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    // followers
+
+    @Test
+    void MetricsService_IncrementFollowers_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.incrementFollowers(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_IncrementFollowers_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.incrementFollowers(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementFollowers_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.decrementFollowers(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementFollowers_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.decrementFollowers(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    // posts
+
+    @Test
+    void MetricsService_IncrementPosts_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.incrementPosts(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_IncrementPosts_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.incrementPosts(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementPosts_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.decrementPosts(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementPosts_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.decrementPosts(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    // media
+
+    @Test
+    void MetricsService_IncrementMedia_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.incrementMedia(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_IncrementMedia_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.incrementMedia(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementMedia_ReturnVoid() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.of(expected));
+
+        // act & assert
+        assertDoesNotThrow(() -> metricsService.decrementMedia(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+    @Test
+    void MetricsService_DecrementMedia_ThrowIdNotFound() {
+        // arrange
+        UUID uuid = UUID.randomUUID();
+        when(metricsRepository.findById(uuid)).thenReturn(Optional.empty());
+
+        // act & assert
+        assertThrows(IdNotFoundException.class, () -> metricsService.decrementMedia(uuid));
+        verify(metricsRepository, times(1)).findById(uuid);
+    }
+
+}

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.echo_api.unit.service;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -37,27 +36,6 @@ class ProfileServiceTest {
 
     @InjectMocks
     private ProfileServiceImpl profileService;
-
-    /**
-     * Test ensures that the {@link ProfileServiceImpl#registerForUser(Account)}
-     * method correctly creates a new profile for the supplied account.
-     */
-    @Test
-    void ProfileService_RegisterForUser_ReturnProfile() {
-        // arrange
-        Account account = new Account("test", "test");
-        Profile expected = new Profile(account);
-
-        when(profileRepository.save(any(Profile.class))).thenReturn(expected);
-
-        // act
-        Profile actual = profileService.registerForAccount(account);
-
-        // assert
-        assertNotNull(actual);
-        assertEquals(expected, actual);
-        verify(profileRepository, times(1)).save(any(Profile.class));
-    }
 
     /**
      * Test ensures that the {@link ProfileServiceImpl#getByUsername(String)} method

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -46,7 +46,7 @@ class ProfileServiceTest {
         // arrange
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toResponse(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile);
 
         when(profileRepository.findByUsername(profile.getUsername())).thenReturn(Optional.of(profile));
 
@@ -84,7 +84,7 @@ class ProfileServiceTest {
         // arrange
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toResponse(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile);
 
         when(sessionService.getAuthenticatedUser()).thenReturn(account);
         when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -16,8 +16,10 @@ import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.profile.Metrics;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.repository.ProfileRepository;
+import com.example.echo_api.service.metrics.MetricsService;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.service.profile.ProfileServiceImpl;
 import com.example.echo_api.service.session.SessionService;
@@ -32,6 +34,9 @@ class ProfileServiceTest {
     private SessionService sessionService;
 
     @Mock
+    private MetricsService metricsService;
+
+    @Mock
     private ProfileRepository profileRepository;
 
     @InjectMocks
@@ -42,13 +47,15 @@ class ProfileServiceTest {
      * correctly returns the profile when the username exists.
      */
     @Test
-    void ProfileService_GetByUsername_ReturnProfileResponse() {
+    void ProfileService_GetByUsername_ReturnProfileDTO() {
         // arrange
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toDTO(profile);
+        Metrics metrics = new Metrics(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics);
 
         when(profileRepository.findByUsername(profile.getUsername())).thenReturn(Optional.of(profile));
+        when(metricsService.getMetrics(profile.getProfileId())).thenReturn(metrics);
 
         // act
         ProfileDTO actual = profileService.getByUsername(profile.getUsername());
@@ -84,10 +91,12 @@ class ProfileServiceTest {
         // arrange
         Account account = new Account("test", "test");
         Profile profile = new Profile(account);
-        ProfileDTO expected = ProfileMapper.toDTO(profile);
+        Metrics metrics = new Metrics(profile);
+        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics);
 
         when(sessionService.getAuthenticatedUser()).thenReturn(account);
         when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
+        when(metricsService.getMetrics(profile.getProfileId())).thenReturn(metrics);
 
         // act
         ProfileDTO actual = profileService.getMe();


### PR DESCRIPTION
## Purpose
PR introduces business logic for profile metrics

## Changelog
- Removed metrics from `profile` db table and corresponding entity
- Added `profile_metrics` db table and corresponding entity
- Added `MetricsRepository` for data access
- Implemented `MetricsService` with methods for managing profile metrics. 
- Updated `AccountService#register` to create an account, profile, and metrics on registration
- Added `MetricsDTO` and updated `ProfileDTO` to include `MetricsDTO`
- Updated `ProfileMapper` to correctly accept `Profile` and `Metrics` objects, returning the updated `ProfileDTO`
- Extended `ProfileService` to fetch metrics when retrieving a profile, returning the combined `ProfileDTO`
- Wrote `MetricsService` and `ProfileMapper` unit tests
- Updated existing tests to reflect refactored methods and class names
