### PR TITLE
feat: profile followers and following lists

### DIFF
--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.controller.profile;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,15 +50,15 @@ public class ProfileController {
     // --- following/follower list ----
 
     @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
-    public ResponseEntity<Void> getFollowers(@PathVariable("username") String username) {
-        // TODO: implement
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<List<ProfileDTO>> getFollowers(@PathVariable("username") String username) {
+        List<ProfileDTO> response = profileService.getFollowers(username);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
-    public ResponseEntity<Void> getFollowing(@PathVariable("username") String username) {
-        // TODO: implement
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<List<ProfileDTO>> getFollowing(@PathVariable("username") String username) {
+        List<ProfileDTO> response = profileService.getFollowing(username);
+        return ResponseEntity.ok(response);
     }
 
     // --- follow ----

--- a/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
@@ -1,14 +1,50 @@
 package com.example.echo_api.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.example.echo_api.persistence.model.profile.Profile;
 
-public interface ProfileRepository extends ListCrudRepository<Profile, UUID> {
+public interface ProfileRepository extends CrudRepository<Profile, UUID>, PagingAndSortingRepository<Profile, UUID> {
 
+    /**
+     * Find a {@link Profile} by {@code username}.
+     * 
+     * @param username The username to search for.
+     * @return An {@link Optional} containing the {@link Profile} if found,
+     *         otherwise empty.
+     */
     Optional<Profile> findByUsername(String username);
+
+    /**
+     * Find all {@link Profile} for followers of the supplied {@code profileId}.
+     * 
+     * @param profileId The id of the profile to search against.
+     * @return A list containing the profiles of matches if any exist, otherwise
+     *         empty.
+     */
+    @Query("SELECT p FROM Profile p " +
+        "JOIN Follow f ON p.id = f.followerId " +
+        "WHERE f.followingId = :profileId")
+    List<Profile> findAllFollowersById(@Param("profileId") UUID profileId);
+
+    /**
+     * Find all {@link Profile} for those followed by the supplied
+     * {@code profileId}.
+     * 
+     * @param profileId The id of the profile to search against.
+     * @return A list containing the profiles of matches if any exist, otherwise
+     *         empty.
+     */
+    @Query("SELECT p FROM Profile p " +
+        "JOIN Follow f ON p.id = f.followingId " +
+        "WHERE f.followerId = :profileId")
+    List<Profile> findAllFollowingById(@Param("profileId") UUID profileId);
 
 }

--- a/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
@@ -23,7 +23,8 @@ public interface ProfileRepository extends CrudRepository<Profile, UUID>, Paging
     Optional<Profile> findByUsername(String username);
 
     /**
-     * Find all {@link Profile} for followers of the supplied {@code profileId}.
+     * Find all {@link Profile} for followers of the supplied {@code profileId} in
+     * descending order (newest first).
      * 
      * @param profileId The id of the profile to search against.
      * @return A list containing the profiles of matches if any exist, otherwise
@@ -31,12 +32,13 @@ public interface ProfileRepository extends CrudRepository<Profile, UUID>, Paging
      */
     @Query("SELECT p FROM Profile p " +
         "JOIN Follow f ON p.id = f.followerId " +
-        "WHERE f.followingId = :profileId")
+        "WHERE f.followingId = :profileId " +
+        "ORDER BY f.createdAt DESC")
     List<Profile> findAllFollowersById(@Param("profileId") UUID profileId);
 
     /**
-     * Find all {@link Profile} for those followed by the supplied
-     * {@code profileId}.
+     * Find all {@link Profile} for those followed by the supplied {@code profileId}
+     * in descending order (newest first).
      * 
      * @param profileId The id of the profile to search against.
      * @return A list containing the profiles of matches if any exist, otherwise
@@ -44,7 +46,8 @@ public interface ProfileRepository extends CrudRepository<Profile, UUID>, Paging
      */
     @Query("SELECT p FROM Profile p " +
         "JOIN Follow f ON p.id = f.followingId " +
-        "WHERE f.followerId = :profileId")
+        "WHERE f.followerId = :profileId " +
+        "ORDER BY f.createdAt DESC")
     List<Profile> findAllFollowingById(@Param("profileId") UUID profileId);
 
 }

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.service.profile;
 
+import java.util.List;
+
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
@@ -35,6 +37,26 @@ public interface ProfileService {
      *                profile information.
      */
     public void updateMeProfile(UpdateProfileDTO request);
+
+    /**
+     * Fetches a {@link List} of {@link Profile} for the followers list of the
+     * supplied {@code username}.
+     * 
+     * @param username The username of the profile to search against.
+     * @return A {@link List} of {@link Profile} for matches, otherwise empty.
+     * @throws UsernameNotFoundException If the username is not found.
+     */
+    public List<ProfileDTO> getFollowers(String username) throws UsernameNotFoundException;
+
+    /**
+     * Fetches a {@link List} of {@link Profile} for the following list of the
+     * supplied {@code username}.
+     * 
+     * @param username The username of the profile to search against.
+     * @return A {@link List} of {@link Profile} for matches, otherwise empty.
+     * @throws UsernameNotFoundException If the username is not found.
+     */
+    public List<ProfileDTO> getFollowing(String username) throws UsernameNotFoundException;
 
     /**
      * Create a {@link Follow} relationship between the authenticated profile and

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.service.profile;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +57,34 @@ public class ProfileServiceImpl implements ProfileService {
         Profile me = findMe();
         ProfileMapper.updateProfile(request, me);
         profileRepository.save(me);
+    }
+
+    @Override
+    public List<ProfileDTO> getFollowers(String username) throws UsernameNotFoundException {
+        Profile me = findMe();
+        Profile target = findByUsername(username);
+        List<Profile> followersList = profileRepository.findAllFollowersById(target.getProfileId());
+
+        return followersList.stream()
+            .map(follower -> ProfileMapper.toDTO(
+                follower,
+                profileMetricsService.getMetrics(follower),
+                relationshipService.getRelationship(me, follower)))
+            .toList();
+    }
+
+    @Override
+    public List<ProfileDTO> getFollowing(String username) throws UsernameNotFoundException {
+        Profile me = findMe();
+        Profile target = findByUsername(username);
+        List<Profile> followingList = profileRepository.findAllFollowingById(target.getProfileId());
+
+        return followingList.stream()
+            .map(following -> ProfileMapper.toDTO(
+                following,
+                profileMetricsService.getMetrics(following),
+                relationshipService.getRelationship(me, following)))
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/example/echo_api/service/relationship/RelationshipServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/relationship/RelationshipServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.service.relationship;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,10 @@ public class RelationshipServiceImpl implements RelationshipService {
 
     @Override
     public RelationshipDTO getRelationship(Profile source, Profile target) {
+        if (isSelfAction(source, target)) {
+            return null;
+        }
+
         boolean isFollowing = followService.isFollowing(source, target);
         boolean isFollowedBy = followService.isFollowedBy(source, target);
         boolean isBlocking = blockService.isBlocking(source, target);
@@ -71,6 +77,17 @@ public class RelationshipServiceImpl implements RelationshipService {
     @Override
     public void unblock(Profile source, Profile target) throws SelfActionException, NotBlockingException {
         blockService.unblock(source, target);
+    }
+
+    /**
+     * Internal method for checking if {@link Profile} pairs match.
+     * 
+     * @param source The source {@link Profile}.
+     * @param target The target {@link Profile}.
+     * @return Boolean indicating whether the profiles are a match.
+     */
+    private boolean isSelfAction(Profile source, Profile target) {
+        return Objects.equals(source.getProfileId(), target.getProfileId());
     }
 
     /**

--- a/src/test/java/com/example/echo_api/unit/service/RelationshipServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/RelationshipServiceTest.java
@@ -20,6 +20,7 @@ import com.example.echo_api.exception.custom.relationship.BlockedException;
 import com.example.echo_api.exception.custom.relationship.NotBlockingException;
 import com.example.echo_api.exception.custom.relationship.NotFollowingException;
 import com.example.echo_api.exception.custom.relationship.SelfActionException;
+import com.example.echo_api.persistence.dto.response.profile.RelationshipDTO;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.service.relationship.RelationshipService;
@@ -58,6 +59,42 @@ class RelationshipServiceTest {
         idField.setAccessible(true);
         idField.set(source, UUID.randomUUID());
         idField.set(target, UUID.randomUUID());
+    }
+
+    /**
+     * Test ensures that
+     * {@link RelationshipServiceImpl#getRelationship(Profile, Profile)} correctly
+     * returns {@link RelationshipDTO}.
+     */
+    @Test
+    void RelationshipService_GetRelationship_ReturnRelationshipDto() {
+        // arrange
+        RelationshipDTO expected = new RelationshipDTO(false, false, false, false);
+        when(followService.isFollowing(source, target)).thenReturn(false);
+        when(followService.isFollowedBy(source, target)).thenReturn(false);
+        when(blockService.isBlocking(source, target)).thenReturn(false);
+        when(blockService.isBlockedBy(source, target)).thenReturn(false);
+
+        // act
+        RelationshipDTO actual = relationshipService.getRelationship(source, target);
+
+        // assert
+        assertNotNull(actual);
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test ensures that
+     * {@link RelationshipServiceImpl#getRelationship(Profile, Profile)} correctly
+     * returns {@code null} when the supplied {@link Profile} are equal.
+     */
+    @Test
+    void RelationshipService_GetRelationship_ReturnNull() {
+        // act
+        RelationshipDTO relationship = relationshipService.getRelationship(source, source);
+
+        // assert
+        assertNull(relationship);
     }
 
     /**


### PR DESCRIPTION
## Purpose
PR introduces the ability to fetch the follower and following lists of profiles for the queried username

### Relevant endpoints

`GET /api/v1/profile/{username}/followers`
`GET /api/v1/profile/{username}/following`

Note that the endpoints will fetch an array of all profiles, and there is currently no limit to the size of the array. Pagination will be introduced at a later point.

## Changelog
- Added custom queries to `ProfileRepository` to fetch profiles of those who follow/are followed by a given profile returned as a list
- Added `isSelfAction` check to `RelationshipService.getRelationship` to prevent invalid DB reads
- Added `ProfileService` `getFollowers` `getFollowing` methods to enable fetching of follower/following lists by `username`
- Added `ProfileController` `getFollowers` `getFollowing` methods to enable client to fetch follower/following lists
- Added additional `ProfileRepositoryIT` integration tests to support implemented custom queries
- Added additional `ProfileSerivceTest` unit tests to support implemented methods
- Added additional `RelationshipServiceTest` unit tests to support missing testing of `getRelationship` method