### PR TITLE
feat: pagination

### DIFF
--- a/src/main/java/com/example/echo_api/config/ValidationMessageConfig.java
+++ b/src/main/java/com/example/echo_api/config/ValidationMessageConfig.java
@@ -10,6 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class ValidationMessageConfig {
 
+    /* Pagination */
+    public static final String INVALID_OFFSET = "Offset index must not be negative.";
+    public static final String INVALID_LIMIT = "Limit must be in the range 1 to 50.";
+
     /* Account */
     public static final String INVALID_USERNAME = "Username must be 3-15 characters long and can only include alphanumerics or underscores.";
     public static final String INVALID_PASSWORD = "Password must be at least 6 characters long and contain at least 1 letter and 1 number.";

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -1,5 +1,6 @@
 package com.example.echo_api.controller.profile;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.service.profile.ProfileService;
+import com.example.echo_api.util.pagination.OffsetLimitRequest;
 import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import jakarta.validation.Valid;
@@ -56,7 +58,8 @@ public class ProfileController {
         @RequestParam(required = true) int offset,
         @RequestParam(required = true) int limit
     ) {
-        PageDTO<ProfileDTO> response = profileService.getFollowers(username, offset, limit);
+        Pageable page = new OffsetLimitRequest(offset, limit);
+        PageDTO<ProfileDTO> response = profileService.getFollowers(username, page);
         return ResponseEntity.ok(response);
     }
 
@@ -66,7 +69,8 @@ public class ProfileController {
         @RequestParam(required = true) int offset,
         @RequestParam(required = true) int limit
     ) {
-        PageDTO<ProfileDTO> response = profileService.getFollowing(username, offset, limit);
+        Pageable page = new OffsetLimitRequest(offset, limit);
+        PageDTO<ProfileDTO> response = profileService.getFollowing(username, page);
         return ResponseEntity.ok(response);
     }
     // @formatter:on

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -1,12 +1,12 @@
 package com.example.echo_api.controller.profile;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.validation.sequence.ValidationOrder;
@@ -51,22 +51,22 @@ public class ProfileController {
 
     // @formatter:off
     @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
-    public ResponseEntity<Page<ProfileDTO>> getFollowers(
+    public ResponseEntity<PageDTO<ProfileDTO>> getFollowers(
         @PathVariable("username") String username,
         @RequestParam(required = true) int offset,
         @RequestParam(required = true) int limit
     ) {
-        Page<ProfileDTO> response = profileService.getFollowers(username, offset, limit);
+        PageDTO<ProfileDTO> response = profileService.getFollowers(username, offset, limit);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
-    public ResponseEntity<Page<ProfileDTO>> getFollowing(
+    public ResponseEntity<PageDTO<ProfileDTO>> getFollowing(
         @PathVariable("username") String username,
         @RequestParam(required = true) int offset,
         @RequestParam(required = true) int limit
     ) {
-        Page<ProfileDTO> response = profileService.getFollowing(username, offset, limit);
+        PageDTO<ProfileDTO> response = profileService.getFollowing(username, offset, limit);
         return ResponseEntity.ok(response);
     }
     // @formatter:on

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -1,7 +1,6 @@
 package com.example.echo_api.controller.profile;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,17 +49,27 @@ public class ProfileController {
 
     // --- following/follower list ----
 
+    // @formatter:off
     @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
-    public ResponseEntity<List<ProfileDTO>> getFollowers(@PathVariable("username") String username) {
-        List<ProfileDTO> response = profileService.getFollowers(username);
+    public ResponseEntity<Page<ProfileDTO>> getFollowers(
+        @PathVariable("username") String username,
+        @RequestParam(required = true) int offset,
+        @RequestParam(required = true) int limit
+    ) {
+        Page<ProfileDTO> response = profileService.getFollowers(username, offset, limit);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
-    public ResponseEntity<List<ProfileDTO>> getFollowing(@PathVariable("username") String username) {
-        List<ProfileDTO> response = profileService.getFollowing(username);
+    public ResponseEntity<Page<ProfileDTO>> getFollowing(
+        @PathVariable("username") String username,
+        @RequestParam(required = true) int offset,
+        @RequestParam(required = true) int limit
+    ) {
+        Page<ProfileDTO> response = profileService.getFollowing(username, offset, limit);
         return ResponseEntity.ok(response);
     }
+    // @formatter:on
 
     // --- follow ----
 

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -11,7 +11,8 @@ import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.util.pagination.OffsetLimitRequest;
-import com.example.echo_api.validation.sequence.ValidationOrder;
+import com.example.echo_api.validation.pagination.annotations.Limit;
+import com.example.echo_api.validation.pagination.annotations.Offset;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
+@Validated
 public class ProfileController {
 
     private final ProfileService profileService;
@@ -55,8 +56,8 @@ public class ProfileController {
     @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
     public ResponseEntity<PageDTO<ProfileDTO>> getFollowers(
         @PathVariable("username") String username,
-        @RequestParam(required = true) int offset,
-        @RequestParam(required = true) int limit
+        @RequestParam(defaultValue = "0") @Offset int offset,
+        @RequestParam(defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
         PageDTO<ProfileDTO> response = profileService.getFollowers(username, page);
@@ -66,8 +67,8 @@ public class ProfileController {
     @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
     public ResponseEntity<PageDTO<ProfileDTO>> getFollowing(
         @PathVariable("username") String username,
-        @RequestParam(required = true) int offset,
-        @RequestParam(required = true) int limit
+        @RequestParam(defaultValue = "0") @Offset int offset,
+        @RequestParam(defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
         PageDTO<ProfileDTO> response = profileService.getFollowing(username, page);

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -56,8 +56,8 @@ public class ProfileController {
     @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
     public ResponseEntity<PageDTO<ProfileDTO>> getFollowers(
         @PathVariable("username") String username,
-        @RequestParam(defaultValue = "0") @Offset int offset,
-        @RequestParam(defaultValue = "20") @Limit int limit
+        @RequestParam(name = "offset", defaultValue = "0") @Offset int offset,
+        @RequestParam(name = "limit", defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
         PageDTO<ProfileDTO> response = profileService.getFollowers(username, page);
@@ -67,8 +67,8 @@ public class ProfileController {
     @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
     public ResponseEntity<PageDTO<ProfileDTO>> getFollowing(
         @PathVariable("username") String username,
-        @RequestParam(defaultValue = "0") @Offset int offset,
-        @RequestParam(defaultValue = "20") @Limit int limit
+        @RequestParam(name = "offset", defaultValue = "0") @Offset int offset,
+        @RequestParam(name = "limit", defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
         PageDTO<ProfileDTO> response = profileService.getFollowing(username, page);

--- a/src/main/java/com/example/echo_api/persistence/dto/response/pagination/PageDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/response/pagination/PageDTO.java
@@ -1,0 +1,32 @@
+package com.example.echo_api.persistence.dto.response.pagination;
+
+import java.util.List;
+
+/**
+ * Represents a standardised pagination response format for the application,
+ * intended to replace the Spring default
+ * {@link org.springframework.data.domain.Page}.
+ * 
+ * <p>
+ * Accepts a generic type {@code T} for the content type.
+ * 
+ * @param previous The {@code URI} to fetch the previous page, assuming the same
+ *                 page size.
+ * @param next     The {@code URI} to fetch the next page, assuming the same
+ *                 page size.
+ * @param limit    The size of this page.
+ * @param offset   The offset of data fetched in this page (page size * page
+ *                 number).
+ * @param total    The total number of items available from this resource.
+ * @param items    The list of content returned in this response.
+ */
+// @formatter:off
+public record PageDTO<T>(
+    String previous,
+    String next,
+    int offset,
+    int limit,
+    int total,
+    List<T> items
+) {}
+// @formatter:on

--- a/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
@@ -3,12 +3,9 @@ package com.example.echo_api.persistence.mapper;
 import static lombok.AccessLevel.PRIVATE;
 
 import org.springframework.data.domain.Page;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.NoArgsConstructor;
 
 /**
@@ -19,10 +16,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public class PageMapper {
 
-    public static <T> PageDTO<T> toDTO(Page<T> page, int offset, int limit) {
-        String path = getCurrentUri();
-        String previous = page.hasPrevious() ? constructPreviousUri(path, offset, limit) : null;
-        String next = page.hasNext() ? constructNextUri(path, offset, limit) : null;
+    public static <T> PageDTO<T> toDTO(Page<T> page, String uri, int offset, int limit) {
+        String previous = page.hasPrevious() ? constructPreviousUri(uri, offset, limit) : null;
+        String next = page.hasNext() ? constructNextUri(uri, offset, limit) : null;
 
         return new PageDTO<>(
             previous,
@@ -31,13 +27,6 @@ public class PageMapper {
             limit,
             (int) page.getTotalElements(),
             page.getContent());
-    }
-
-    private static String getCurrentUri() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
-            .currentRequestAttributes()).getRequest();
-
-        return request.getRequestURI();
     }
 
     private static String constructPreviousUri(String path, int offset, int limit) {

--- a/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
@@ -1,0 +1,53 @@
+package com.example.echo_api.persistence.mapper;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility mapper to convert the default Spring pagination {@link Page} to a
+ * custom {@link PageDTO}, which returns more concise information to the client
+ * than the default.
+ */
+@NoArgsConstructor(access = PRIVATE)
+public class PageMapper {
+
+    public static <T> PageDTO<T> toDTO(Page<T> page, int offset, int limit) {
+        String path = getCurrentUri();
+        String previous = page.hasPrevious() ? constructPreviousUri(path, offset, limit) : null;
+        String next = page.hasNext() ? constructNextUri(path, offset, limit) : null;
+
+        return new PageDTO<>(
+            previous,
+            next,
+            offset,
+            limit,
+            (int) page.getTotalElements(),
+            page.getContent());
+    }
+
+    private static String getCurrentUri() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+            .currentRequestAttributes()).getRequest();
+
+        return request.getRequestURI();
+    }
+
+    private static String constructPreviousUri(String path, int offset, int limit) {
+        String pagination = String.format("?offset=%d&limit=%d", offset - limit, limit);
+        return path + pagination;
+    }
+
+    private static String constructNextUri(String path, int offset, int limit) {
+        String pagination = String.format("?offset=%d&limit=%d", offset + limit, limit);
+        return path + pagination;
+    }
+
+}

--- a/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/PageMapper.java
@@ -16,7 +16,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public class PageMapper {
 
-    public static <T> PageDTO<T> toDTO(Page<T> page, String uri, int offset, int limit) {
+    public static <T> PageDTO<T> toDTO(Page<T> page, String uri) {
+        int offset = (int) page.getPageable().getOffset();
+        int limit = page.getPageable().getPageSize();
+
         String previous = page.hasPrevious() ? constructPreviousUri(uri, offset, limit) : null;
         String next = page.hasNext() ? constructNextUri(uri, offset, limit) : null;
 

--- a/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/ProfileRepository.java
@@ -1,9 +1,10 @@
 package com.example.echo_api.persistence.repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -34,7 +35,7 @@ public interface ProfileRepository extends CrudRepository<Profile, UUID>, Paging
         "JOIN Follow f ON p.id = f.followerId " +
         "WHERE f.followingId = :profileId " +
         "ORDER BY f.createdAt DESC")
-    List<Profile> findAllFollowersById(@Param("profileId") UUID profileId);
+    Page<Profile> findAllFollowersById(@Param("profileId") UUID profileId, Pageable p);
 
     /**
      * Find all {@link Profile} for those followed by the supplied {@code profileId}
@@ -48,6 +49,6 @@ public interface ProfileRepository extends CrudRepository<Profile, UUID>, Paging
         "JOIN Follow f ON p.id = f.followingId " +
         "WHERE f.followerId = :profileId " +
         "ORDER BY f.createdAt DESC")
-    List<Profile> findAllFollowingById(@Param("profileId") UUID profileId);
+    Page<Profile> findAllFollowingById(@Param("profileId") UUID profileId, Pageable p);
 
 }

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -2,10 +2,9 @@ package com.example.echo_api.service.profile;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.model.follow.Follow;
 import com.example.echo_api.persistence.model.profile.Profile;
@@ -48,7 +47,7 @@ public interface ProfileService {
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public Page<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException;
+    public PageDTO<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException;
 
     /**
      * Fetches a {@link List} of {@link Profile} for the following list of the
@@ -58,7 +57,7 @@ public interface ProfileService {
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public Page<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException;
+    public PageDTO<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException;
 
     /**
      * Create a {@link Follow} relationship between the authenticated profile and

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -2,6 +2,8 @@ package com.example.echo_api.service.profile;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
@@ -46,7 +48,7 @@ public interface ProfileService {
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public List<ProfileDTO> getFollowers(String username) throws UsernameNotFoundException;
+    public Page<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException;
 
     /**
      * Fetches a {@link List} of {@link Profile} for the following list of the
@@ -56,7 +58,7 @@ public interface ProfileService {
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public List<ProfileDTO> getFollowing(String username) throws UsernameNotFoundException;
+    public Page<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException;
 
     /**
      * Create a {@link Follow} relationship between the authenticated profile and

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -2,6 +2,8 @@ package com.example.echo_api.service.profile;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
@@ -41,23 +43,25 @@ public interface ProfileService {
 
     /**
      * Fetches a {@link List} of {@link Profile} for the followers list of the
-     * supplied {@code username}.
+     * supplied {@code username} and {@code page} parameters.
      * 
      * @param username The username of the profile to search against.
+     * @param page     The {@link Pageable} containing the pagination parameters.
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public PageDTO<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException;
+    public PageDTO<ProfileDTO> getFollowers(String username, Pageable page) throws UsernameNotFoundException;
 
     /**
      * Fetches a {@link List} of {@link Profile} for the following list of the
-     * supplied {@code username}.
+     * supplied {@code username} and {@code page} parameters.
      * 
      * @param username The username of the profile to search against.
+     * @param page     The {@link Pageable} containing the pagination parameters.
      * @return A {@link List} of {@link Profile} for matches, otherwise empty.
      * @throws UsernameNotFoundException If the username is not found.
      */
-    public PageDTO<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException;
+    public PageDTO<ProfileDTO> getFollowing(String username, Pageable page) throws UsernameNotFoundException;
 
     /**
      * Create a {@link Follow} relationship between the authenticated profile and

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -1,7 +1,8 @@
 package com.example.echo_api.service.profile;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,31 +61,29 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public List<ProfileDTO> getFollowers(String username) throws UsernameNotFoundException {
+    public Page<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException {
+        Pageable page = PageRequest.of((offset / limit), limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
-        List<Profile> followersList = profileRepository.findAllFollowersById(target.getProfileId());
+        Page<Profile> followersList = profileRepository.findAllFollowersById(target.getProfileId(), page);
 
-        return followersList.stream()
-            .map(follower -> ProfileMapper.toDTO(
-                follower,
-                profileMetricsService.getMetrics(follower),
-                relationshipService.getRelationship(me, follower)))
-            .toList();
+        return followersList.map(following -> ProfileMapper.toDTO(
+            following,
+            profileMetricsService.getMetrics(following),
+            relationshipService.getRelationship(me, following)));
     }
 
     @Override
-    public List<ProfileDTO> getFollowing(String username) throws UsernameNotFoundException {
+    public Page<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException {
+        Pageable page = PageRequest.of((offset / limit), limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
-        List<Profile> followingList = profileRepository.findAllFollowingById(target.getProfileId());
+        Page<Profile> followingList = profileRepository.findAllFollowingById(target.getProfileId(), page);
 
-        return followingList.stream()
-            .map(following -> ProfileMapper.toDTO(
-                following,
-                profileMetricsService.getMetrics(following),
-                relationshipService.getRelationship(me, following)))
-            .toList();
+        return followingList.map(following -> ProfileMapper.toDTO(
+            following,
+            profileMetricsService.getMetrics(following),
+            relationshipService.getRelationship(me, following)));
     }
 
     @Override

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.echo_api.service.profile;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +17,7 @@ import com.example.echo_api.persistence.repository.ProfileRepository;
 import com.example.echo_api.service.metrics.profile.ProfileMetricsService;
 import com.example.echo_api.service.relationship.RelationshipService;
 import com.example.echo_api.service.session.SessionService;
+import com.example.echo_api.util.OffsetLimitRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -62,7 +62,7 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Override
     public Page<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException {
-        Pageable page = PageRequest.of((offset / limit), limit);
+        Pageable page = new OffsetLimitRequest(offset, limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
         Page<Profile> followersList = profileRepository.findAllFollowersById(target.getProfileId(), page);
@@ -75,7 +75,7 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Override
     public Page<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException {
-        Pageable page = PageRequest.of((offset / limit), limit);
+        Pageable page = new OffsetLimitRequest(offset, limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
         Page<Profile> followingList = profileRepository.findAllFollowingById(target.getProfileId(), page);

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -7,9 +7,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.MetricsDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.RelationshipDTO;
+import com.example.echo_api.persistence.mapper.PageMapper;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.model.profile.Profile;
@@ -17,7 +19,7 @@ import com.example.echo_api.persistence.repository.ProfileRepository;
 import com.example.echo_api.service.metrics.profile.ProfileMetricsService;
 import com.example.echo_api.service.relationship.RelationshipService;
 import com.example.echo_api.service.session.SessionService;
-import com.example.echo_api.util.OffsetLimitRequest;
+import com.example.echo_api.util.pagination.OffsetLimitRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -61,29 +63,33 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public Page<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException {
+    public PageDTO<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException {
         Pageable page = new OffsetLimitRequest(offset, limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
         Page<Profile> followersList = profileRepository.findAllFollowersById(target.getProfileId(), page);
 
-        return followersList.map(following -> ProfileMapper.toDTO(
+        Page<ProfileDTO> mappedFollowersList = followersList.map(following -> ProfileMapper.toDTO(
             following,
             profileMetricsService.getMetrics(following),
             relationshipService.getRelationship(me, following)));
+
+        return PageMapper.toDTO(mappedFollowersList, offset, limit);
     }
 
     @Override
-    public Page<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException {
+    public PageDTO<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException {
         Pageable page = new OffsetLimitRequest(offset, limit);
         Profile me = findMe();
         Profile target = findByUsername(username);
         Page<Profile> followingList = profileRepository.findAllFollowingById(target.getProfileId(), page);
 
-        return followingList.map(following -> ProfileMapper.toDTO(
+        Page<ProfileDTO> mappedfollowingList = followingList.map(following -> ProfileMapper.toDTO(
             following,
             profileMetricsService.getMetrics(following),
             relationshipService.getRelationship(me, following)));
+
+        return PageMapper.toDTO(mappedfollowingList, offset, limit);
     }
 
     @Override

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -19,7 +19,6 @@ import com.example.echo_api.persistence.repository.ProfileRepository;
 import com.example.echo_api.service.metrics.profile.ProfileMetricsService;
 import com.example.echo_api.service.relationship.RelationshipService;
 import com.example.echo_api.service.session.SessionService;
-import com.example.echo_api.util.pagination.OffsetLimitRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -66,11 +65,9 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public PageDTO<ProfileDTO> getFollowers(String username, int offset, int limit) throws UsernameNotFoundException {
+    public PageDTO<ProfileDTO> getFollowers(String username, Pageable page) throws UsernameNotFoundException {
         Profile me = findMe();
         Profile target = findByUsername(username);
-
-        Pageable page = new OffsetLimitRequest(offset, limit);
         Page<Profile> followersPage = profileRepository.findAllFollowersById(target.getProfileId(), page);
 
         Page<ProfileDTO> followersDtoPage = followersPage.map(profile -> ProfileMapper.toDTO(
@@ -79,15 +76,13 @@ public class ProfileServiceImpl implements ProfileService {
             relationshipService.getRelationship(me, profile)));
 
         String uri = getCurrentRequestUri();
-        return PageMapper.toDTO(followersDtoPage, uri, offset, limit);
+        return PageMapper.toDTO(followersDtoPage, uri);
     }
 
     @Override
-    public PageDTO<ProfileDTO> getFollowing(String username, int offset, int limit) throws UsernameNotFoundException {
+    public PageDTO<ProfileDTO> getFollowing(String username, Pageable page) throws UsernameNotFoundException {
         Profile me = findMe();
         Profile target = findByUsername(username);
-
-        Pageable page = new OffsetLimitRequest(offset, limit);
         Page<Profile> followingPage = profileRepository.findAllFollowingById(target.getProfileId(), page);
 
         Page<ProfileDTO> followingDtoPage = followingPage.map(profile -> ProfileMapper.toDTO(
@@ -96,7 +91,7 @@ public class ProfileServiceImpl implements ProfileService {
             relationshipService.getRelationship(me, profile)));
 
         String uri = getCurrentRequestUri();
-        return PageMapper.toDTO(followingDtoPage, uri, offset, limit);
+        return PageMapper.toDTO(followingDtoPage, uri);
     }
 
     @Override

--- a/src/main/java/com/example/echo_api/util/OffsetLimitRequest.java
+++ b/src/main/java/com/example/echo_api/util/OffsetLimitRequest.java
@@ -1,0 +1,100 @@
+package com.example.echo_api.util;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+
+/**
+ * 
+ */
+public class OffsetLimitRequest implements Pageable {
+
+    private final int offset;
+    private final int limit;
+    private final Sort sort;
+
+    /**
+     * Creates a new {@link OffsetLimitRequest} with sort parameters applied.
+     * 
+     * @param offset Zero-indexed starting position, must not be negative.
+     * @param limit  Maximum number of items to be returned, must be greater than 0.
+     * @param sort   Must not be {@literal null}, use {@link Sort#unsorted()}
+     *               instead.
+     */
+    public OffsetLimitRequest(int offset, int limit, Sort sort) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset index must not be negative.");
+        }
+        if (limit < 1) {
+            throw new IllegalArgumentException("Limit must be greater than 0.");
+        }
+        Assert.notNull(sort, "Sort must not be null");
+
+        this.offset = offset;
+        this.limit = limit;
+        this.sort = sort;
+    }
+
+    /**
+     * Creates a new unsorted {@link OffsetLimitRequest}.
+     * 
+     * @param offset Zero-indexed starting position, must not be negative.
+     * @param limit  Maximum number of items to be returned, must be greater than 0.
+     */
+    public OffsetLimitRequest(int offset, int limit) {
+        this(offset, limit, Sort.unsorted());
+    }
+
+    @Override
+    public int getPageNumber() {
+        return offset / limit;
+    }
+
+    @Override
+    public int getPageSize() {
+        return limit;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public @NonNull Sort getSort() {
+        return sort;
+    }
+
+    @Override
+    public @NonNull Pageable next() {
+        return new OffsetLimitRequest((int) getOffset() + getPageSize(), getPageSize(), getSort());
+    }
+
+    @Override
+    public @NonNull Pageable previousOrFirst() {
+        return hasPrevious() ? previous() : first();
+    }
+
+    public Pageable previous() {
+        return hasPrevious()
+            ? new OffsetLimitRequest((int) getOffset() - getPageSize(), getPageSize(), getSort())
+            : this;
+    }
+
+    @Override
+    public @NonNull Pageable first() {
+        return new OffsetLimitRequest(0, getPageSize(), getSort());
+    }
+
+    @Override
+    public @NonNull Pageable withPage(int pageNumber) {
+        throw new UnsupportedOperationException("Method is not supported by offset/limit pagination.");
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return getOffset() >= getPageSize();
+    }
+
+}

--- a/src/main/java/com/example/echo_api/util/pagination/OffsetLimitRequest.java
+++ b/src/main/java/com/example/echo_api/util/pagination/OffsetLimitRequest.java
@@ -1,12 +1,24 @@
-package com.example.echo_api.util;
+package com.example.echo_api.util.pagination;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
-import org.springframework.util.Assert;
 
 /**
+ * A custom implementation of {@link Pageable} that supports pagination using
+ * <b>offset</b> and <b>limit</b> instead of the traditional page number and
+ * page size.
  * 
+ * <p>
+ * Example usage:
+ * 
+ * <pre>
+ * OffsetLimitRequest pageRequest = new OffsetLimitRequest(10, 20); // Fetch 20 items starting from the 10th item
+ * Page<Item> page = repository.findAll(pageRequest);
+ * </pre>
+ * 
+ * @see Pageable
+ * @see Sort
  */
 public class OffsetLimitRequest implements Pageable {
 
@@ -17,19 +29,23 @@ public class OffsetLimitRequest implements Pageable {
     /**
      * Creates a new {@link OffsetLimitRequest} with sort parameters applied.
      * 
-     * @param offset Zero-indexed starting position, must not be negative.
-     * @param limit  Maximum number of items to be returned, must be greater than 0.
-     * @param sort   Must not be {@literal null}, use {@link Sort#unsorted()}
-     *               instead.
+     * @param offset Zero-indexed starting position.
+     * @param limit  Maximum number of items to be returned.
+     * @param sort   Sort parameters for the data.
+     * @throws IllegalArgumentException if {@code offset} is negative..
+     * @throws IllegalArgumentException if {@code limit} is less than 1.
+     * @throws IllegalArgumentException if {@code sort} is {@literal null}.
      */
-    public OffsetLimitRequest(int offset, int limit, Sort sort) {
+    public OffsetLimitRequest(int offset, int limit, Sort sort) throws IllegalArgumentException {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset index must not be negative.");
         }
         if (limit < 1) {
             throw new IllegalArgumentException("Limit must be greater than 0.");
         }
-        Assert.notNull(sort, "Sort must not be null");
+        if (sort == null) {
+            throw new IllegalArgumentException("Sort must not be null");
+        }
 
         this.offset = offset;
         this.limit = limit;
@@ -39,10 +55,10 @@ public class OffsetLimitRequest implements Pageable {
     /**
      * Creates a new unsorted {@link OffsetLimitRequest}.
      * 
-     * @param offset Zero-indexed starting position, must not be negative.
-     * @param limit  Maximum number of items to be returned, must be greater than 0.
+     * @param offset Zero-indexed starting position.
+     * @param limit  Maximum number of items to be returned.
      */
-    public OffsetLimitRequest(int offset, int limit) {
+    public OffsetLimitRequest(int offset, int limit) throws IllegalArgumentException {
         this(offset, limit, Sort.unsorted());
     }
 

--- a/src/main/java/com/example/echo_api/validation/pagination/annotations/Limit.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/annotations/Limit.java
@@ -1,0 +1,68 @@
+package com.example.echo_api.validation.pagination.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.example.echo_api.config.ValidationMessageConfig;
+import com.example.echo_api.validation.pagination.validators.LimitValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Custom Jakarta Validation annotation for pagination query parameters.
+ *
+ * <p>
+ * The annotated {@link Integer} must meet the requirements for a valid
+ * {@code limit} parameter in pagination.
+ *
+ * <p>
+ * This annotation is intended to be used on method parameters or fields of type
+ * {@link Integer}. When applied, it triggers the validation logic defined in
+ * the associated {@link LimitValidator} class.
+ *
+ * <p>
+ * Example usage:
+ * 
+ * <pre>
+ * {@code
+ * GetMapping("/items")
+ * public ResponseEntity<PageDTO<ItemDTO>> getItems(
+ *     RequestParam @Limit int limit,
+ *     RequestParam int offset
+ * ) {
+ *     // Method implementation
+ * }
+ * </pre>
+ *
+ * <p>
+ * If the validation fails, a {@link ConstraintViolationException} will be
+ * thrown.
+ */
+@Target({ FIELD, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = LimitValidator.class)
+public @interface Limit {
+
+    /**
+     * @return the error message template
+     */
+    String message() default ValidationMessageConfig.INVALID_LIMIT;
+
+    /**
+     * @return the groups the constraint belongs to
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * @return the payload associated to the constraint
+     */
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/example/echo_api/validation/pagination/annotations/Offset.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/annotations/Offset.java
@@ -1,0 +1,68 @@
+package com.example.echo_api.validation.pagination.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.example.echo_api.config.ValidationMessageConfig;
+import com.example.echo_api.validation.pagination.validators.OffsetValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Custom Jakarta Validation annotation for pagination query parameters.
+ *
+ * <p>
+ * The annotated {@link Integer} must meet the requirements for a valid
+ * {@code offset} parameter in pagination.
+ *
+ * <p>
+ * This annotation is intended to be used on method parameters or fields of type
+ * {@link Integer}. When applied, it triggers the validation logic defined in
+ * the associated {@link OffsetValidator} class.
+ *
+ * <p>
+ * Example usage:
+ * 
+ * <pre>
+ * {@code
+ * GetMapping("/items")
+ * public ResponseEntity<PageDTO<ItemDTO>> getItems(
+ *     RequestParam int limit,
+ *     RequestParam @Offset int offset
+ * ) {
+ *     // Method implementation
+ * }
+ * </pre>
+ *
+ * <p>
+ * If the validation fails, a {@link ConstraintViolationException} will be
+ * thrown.
+ */
+@Target({ FIELD, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = OffsetValidator.class)
+public @interface Offset {
+
+    /**
+     * @return the error message template
+     */
+    String message() default ValidationMessageConfig.INVALID_OFFSET;
+
+    /**
+     * @return the groups the constraint belongs to
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * @return the payload associated to the constraint
+     */
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/example/echo_api/validation/pagination/validators/LimitValidator.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/validators/LimitValidator.java
@@ -1,0 +1,29 @@
+package com.example.echo_api.validation.pagination.validators;
+
+import com.example.echo_api.validation.pagination.annotations.Limit;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validator implementation for the {@link Limit} annotation.
+ * 
+ * <p>
+ * This class ensures that {@code limit} arguments/fields as part of pagination
+ * query parameters are valid.
+ * 
+ * <p>
+ * The validator ensures that any specified {@code limit} are within the range
+ * {@code 1} to {@code 50}.
+ * 
+ * @see Limit
+ * @see ConstraintValidator
+ */
+public class LimitValidator implements ConstraintValidator<Limit, Integer> {
+
+    @Override
+    public boolean isValid(Integer limit, ConstraintValidatorContext context) {
+        return limit >= 1 && limit <= 50;
+    }
+
+}

--- a/src/main/java/com/example/echo_api/validation/pagination/validators/OffsetValidator.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/validators/OffsetValidator.java
@@ -1,0 +1,29 @@
+package com.example.echo_api.validation.pagination.validators;
+
+import com.example.echo_api.validation.pagination.annotations.Offset;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validator implementation for the {@link Offset} annotation.
+ * 
+ * <p>
+ * This class ensures that {@code offset} arguments/fields as part of pagination
+ * query parameters are valid.
+ * 
+ * <p>
+ * The validator ensures that any specified {@code offset} are equal to or
+ * greater than 0.
+ * 
+ * @see Offset
+ * @see ConstraintValidator
+ */
+public class OffsetValidator implements ConstraintValidator<Offset, Integer> {
+
+    @Override
+    public boolean isValid(Integer offset, ConstraintValidatorContext context) {
+        return offset >= 0;
+    }
+
+}

--- a/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
+++ b/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -20,6 +21,7 @@ import com.example.echo_api.integration.util.IntegrationTest;
 import com.example.echo_api.integration.util.TestUtils;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.error.ErrorDTO;
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.service.account.AccountService;
@@ -81,9 +83,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_GetByUsername_ReturnProfileDTO() {
         // api: GET /api/v1/profile/{username} ==> 200 : ProfileDTO
         String path = ApiConfig.Profile.GET_BY_USERNAME;
+        String username = existingAccount.getUsername();
 
-        ResponseEntity<ProfileDTO> response = restTemplate.getForEntity(
-            path, ProfileDTO.class, existingAccount.getUsername());
+        ResponseEntity<ProfileDTO> response = restTemplate.getForEntity(path, ProfileDTO.class, username);
 
         // assert response
         assertEquals(OK, response.getStatusCode());
@@ -92,16 +94,172 @@ class ProfileControllerIT extends IntegrationTest {
         // assert body
         ProfileDTO body = response.getBody();
         assertNotNull(body);
-        assertEquals(existingAccount.getUsername(), body.username());
+        assertEquals(username, body.username());
     }
 
     @Test
     void ProfileController_GetByUsername_Throw400UsernameNotFound() {
         // api: GET /api/v1/profile/{username} ==> 400 : UsernameNotFound
         String path = ApiConfig.Profile.GET_BY_USERNAME;
+        String username = "non-existent-user";
 
-        ResponseEntity<ErrorDTO> response = restTemplate.getForEntity(
-            path, ErrorDTO.class, "non-existent-user");
+        ResponseEntity<ErrorDTO> response = restTemplate.getForEntity(path, ErrorDTO.class, username);
+
+        // assert response
+        assertEquals(BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        // assert error
+        ErrorDTO error = response.getBody();
+        assertNotNull(error);
+        assertEquals(BAD_REQUEST.value(), error.status());
+        assertEquals(ErrorMessageConfig.USERNAME_NOT_FOUND, error.message());
+    }
+
+    @Test
+    @Sql(scripts = "/sql/relationship-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void ProfileController_GetFollowers_ReturnPageOfProfileDTO() {
+        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
+        String followPath = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String getFollowersPath = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME + "?offset=0&limit=1";
+        String username = targetUser.getUsername();
+
+        // follow target user to create a follow relationship in the db
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(followPath, null, Void.class, username);
+
+        // assert response
+        assertEquals(NO_CONTENT, response1.getStatusCode());
+        assertNull(response1.getBody());
+
+        // get followers of target user
+        ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
+        };
+        ResponseEntity<PageDTO<ProfileDTO>> response2 = restTemplate.exchange(getFollowersPath, GET, null, typeRef,
+            username);
+
+        // assert response
+        assertEquals(OK, response2.getStatusCode());
+        assertNotNull(response2.getBody());
+
+        PageDTO<ProfileDTO> data = response2.getBody();
+        assertNotNull(data);
+        assertNull(data.previous());
+        assertNull(data.next());
+        assertEquals(1, data.total());
+        assertEquals(1, data.items().size());
+        assertEquals(existingAccount.getUsername(), data.items().get(0).username());
+    }
+
+    @Test
+    void ProfileController_GetFollowers_ReturnPageOfEmpty() {
+        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
+        String username = targetUser.getUsername();
+
+        ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
+        };
+        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, username);
+
+        // assert response
+        assertEquals(OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        PageDTO<ProfileDTO> data = response.getBody();
+        assertNotNull(data);
+        assertNull(data.previous());
+        assertNull(data.next());
+        assertEquals(0, data.total());
+        assertEquals(0, data.items().size());
+    }
+
+    @Test
+    void ProfileController_GetFollowers_Throw400UsernameNotFound() {
+        // api: GET /api/v1/profile/{username}/followers ==> 400 : UsernameNotFound
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
+        String username = "non-existent-user";
+
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, username);
+
+        // assert response
+        assertEquals(BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        // assert error
+        ErrorDTO error = response.getBody();
+        assertNotNull(error);
+        assertEquals(BAD_REQUEST.value(), error.status());
+        assertEquals(ErrorMessageConfig.USERNAME_NOT_FOUND, error.message());
+    }
+
+    @Test
+    @Sql(scripts = "/sql/relationship-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void ProfileController_GetFollowing_ReturnPageOfProfileDTO() {
+        // api: GET /api/v1/profile/{username}/following ==> 400 : PageDTO<ProfileDTO>
+        String followPath = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String getFollowingPath = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME + "?offset=0&limit=1";
+        String followUsername = targetUser.getUsername();
+        String getFollowingUsername = existingAccount.getUsername();
+
+        // follow target user to create a follow relationship in the db
+        ResponseEntity<ErrorDTO> response1 = restTemplate.postForEntity(followPath, null, ErrorDTO.class,
+            followUsername);
+
+        System.out.println("-----------------------");
+        System.out.println(response1.getBody());
+        System.out.println("-----------------------");
+
+        // assert response
+        assertEquals(NO_CONTENT, response1.getStatusCode());
+        assertNull(response1.getBody());
+
+        // get following of existing user
+        ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
+        };
+        ResponseEntity<PageDTO<ProfileDTO>> response2 = restTemplate.exchange(getFollowingPath, GET, null, typeRef,
+            getFollowingUsername);
+
+        // assert response
+        assertEquals(OK, response2.getStatusCode());
+        assertNotNull(response2.getBody());
+
+        PageDTO<ProfileDTO> data = response2.getBody();
+        assertNotNull(data);
+        assertNull(data.previous());
+        assertNull(data.next());
+        assertEquals(1, data.total());
+        assertEquals(1, data.items().size());
+        assertEquals(followUsername, data.items().get(0).username());
+    }
+
+    @Test
+    void ProfileController_GetFollowing_ReturnPageOfEmpty() {
+        // api: GET /api/v1/profile/{username}/following ==> 400 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
+        String username = targetUser.getUsername();
+
+        ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
+        };
+        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, username);
+
+        // assert response
+        assertEquals(OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        PageDTO<ProfileDTO> data = response.getBody();
+        assertNotNull(data);
+        assertNull(data.previous());
+        assertNull(data.next());
+        assertEquals(0, data.total());
+        assertEquals(0, data.items().size());
+    }
+
+    @Test
+    void ProfileController_GetFollowing_Throw400UsernameNotFound() {
+        // api: GET /api/v1/profile/{username}/following ==> 400 : UsernameNotFound
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
+        String username = "non-existent-user";
+
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -119,9 +277,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Follow_Return204NoContent() {
         // api: POST /api/v1/profile/{username}/follow ==> 204 : No Content
         String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String username = targetUser.getUsername();
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(
-            path, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, response.getStatusCode());
@@ -132,9 +290,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Follow_Throw400UsernameNotFound() {
         // api: POST /api/v1/profile/{username}/follow ==> 400 : UsernameNotFound
         String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String username = "non-existent-user";
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, "non-existent-user");
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -151,9 +309,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Follow_ThrowSelfActionException() {
         // api: POST /api/v1/profile/{username}/follow ==> 400 : SelfFollow
         String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String username = existingAccount.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, existingAccount.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -167,21 +325,21 @@ class ProfileControllerIT extends IntegrationTest {
     }
 
     @Test
+    @Sql(scripts = "/sql/relationship-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Follow_ThrowAlreadyFollowingException() {
         // api: POST /api/v1/profile/{username}/follow ==> 400 : AlreadyFollowing
         String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String username = targetUser.getUsername();
 
         // follow the user to create a follow relationship in the db
-        ResponseEntity<Void> response1 = restTemplate.postForEntity(
-            path, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, response1.getStatusCode());
         assertNull(response1.getBody());
 
         // attempt to follow the same user again to force a 400 AlreadyFollowing
-        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, targetUser.getUsername());
+        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response2.getStatusCode());
@@ -200,18 +358,17 @@ class ProfileControllerIT extends IntegrationTest {
         // api: DELETE /api/v1/profile/{username}/unfollow ==> 204 : No Content
         String followPath = ApiConfig.Profile.FOLLOW_BY_USERNAME;
         String unfollowPath = ApiConfig.Profile.UNFOLLOW_BY_USERNAME;
+        String username = targetUser.getUsername();
 
         // follow the user to create a follow relationship in the db
-        ResponseEntity<Void> followResponse = restTemplate.postForEntity(
-            followPath, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> followResponse = restTemplate.postForEntity(followPath, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, followResponse.getStatusCode());
         assertNull(followResponse.getBody());
 
         // unfollow the user
-        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(
-            unfollowPath, DELETE, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(unfollowPath, DELETE, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, unfollowResponse.getStatusCode());
@@ -222,9 +379,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unfollow_Throw400UsernameNotFound() {
         // api: DELETE /api/v1/profile/{username}/unfollow ==> 400 : UsernameNotFound
         String path = ApiConfig.Profile.UNFOLLOW_BY_USERNAME;
+        String username = "non-existent-user";
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, "non-existent-user");
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -241,9 +398,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unfollow_ThrowSelfActionException() {
         // api: DELETE /api/v1/profile/{username}/unfollow ==> 400 : SelfUnfollow
         String path = ApiConfig.Profile.UNFOLLOW_BY_USERNAME;
+        String username = existingAccount.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, existingAccount.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -260,9 +417,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unfollow_ThrowNotFollowingException() {
         // api: DELETE /api/v1/profile/{username}/unfollow ==> 400 : NotFollowing
         String path = ApiConfig.Profile.UNFOLLOW_BY_USERNAME;
+        String username = targetUser.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, targetUser.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -280,9 +437,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Block_Return204NoContent() {
         // api: POST /api/v1/profile/{username}/block ==> 204 : No Content
         String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String username = targetUser.getUsername();
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(
-            path, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, response.getStatusCode());
@@ -293,9 +450,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Block_Throw400UsernameNotFound() {
         // api: POST /api/v1/profile/{username}/block ==> 400 : UsernameNotFound
         String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String username = "non-existent-user";
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, "non-existent-user");
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -312,9 +469,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Block_ThrowSelfActionException() {
         // api: POST /api/v1/profile/{username}/block ==> 400 : SelfBlock
         String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String username = existingAccount.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, existingAccount.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -328,21 +485,21 @@ class ProfileControllerIT extends IntegrationTest {
     }
 
     @Test
+    @Sql(scripts = "/sql/relationship-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Block_ThrowAlreadyBlockingException() {
         // api: POST /api/v1/profile/{username}/block ==> 400 : AlreadyBlocking
         String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String username = targetUser.getUsername();
 
-        // block the user to create a follow relationship in the db
-        ResponseEntity<Void> response1 = restTemplate.postForEntity(
-            path, null, Void.class, targetUser.getUsername());
+        // block the user to create a block relationship in the db
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, response1.getStatusCode());
         assertNull(response1.getBody());
 
         // attempt to block the same user again to force a 400 AlreadyBlocking
-        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(
-            path, null, ErrorDTO.class, targetUser.getUsername());
+        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response2.getStatusCode());
@@ -360,20 +517,19 @@ class ProfileControllerIT extends IntegrationTest {
     @Sql(scripts = "/sql/relationship-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Unblock_Return204NoContent() {
         // api: DELETE /api/v1/profile/{username}/unblock ==> 204 : No Content
-        String followPath = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String unfollowPath = ApiConfig.Profile.UNBLOCK_BY_USERNAME;
+        String blockPath = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String unblockPath = ApiConfig.Profile.UNBLOCK_BY_USERNAME;
+        String username = targetUser.getUsername();
 
         // block the user to create a block relationship in the db
-        ResponseEntity<Void> followResponse = restTemplate.postForEntity(
-            followPath, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> followResponse = restTemplate.postForEntity(blockPath, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, followResponse.getStatusCode());
         assertNull(followResponse.getBody());
 
         // unblock the user
-        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(
-            unfollowPath, DELETE, null, Void.class, targetUser.getUsername());
+        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(unblockPath, DELETE, null, Void.class, username);
 
         // assert response
         assertEquals(NO_CONTENT, unfollowResponse.getStatusCode());
@@ -385,9 +541,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unblock_Throw400UsernameNotFound() {
         // api: DELETE /api/v1/profile/{username}/unblock ==> 400 : UsernameNotFound
         String path = ApiConfig.Profile.UNBLOCK_BY_USERNAME;
+        String username = "non-existent-user";
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, "non-existent-user");
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -404,9 +560,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unblock_ThrowSelfActionException() {
         // api: DELETE /api/v1/profile/{username}/unblock ==> 400 : SelfUnblock
         String path = ApiConfig.Profile.UNBLOCK_BY_USERNAME;
+        String username = existingAccount.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, existingAccount.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());
@@ -423,9 +579,9 @@ class ProfileControllerIT extends IntegrationTest {
     void ProfileController_Unblock_ThrowNotBlockingException() {
         // api: DELETE /api/v1/profile/{username}/unblock ==> 400 : NotBlocking
         String path = ApiConfig.Profile.UNBLOCK_BY_USERNAME;
+        String username = targetUser.getUsername();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(
-            path, DELETE, null, ErrorDTO.class, targetUser.getUsername());
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
 
         // assert response
         assertEquals(BAD_REQUEST, response.getStatusCode());

--- a/src/test/java/com/example/echo_api/integration/repository/ProfileRepositoryIT.java
+++ b/src/test/java/com/example/echo_api/integration/repository/ProfileRepositoryIT.java
@@ -2,7 +2,6 @@ package com.example.echo_api.integration.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -10,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.model.follow.Follow;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.repository.ProfileRepository;
+import com.example.echo_api.util.pagination.OffsetLimitRequest;
 import com.example.echo_api.persistence.repository.AccountRepository;
 import com.example.echo_api.persistence.repository.FollowRepository;
 
@@ -85,37 +87,41 @@ class ProfileRepositoryIT extends RepositoryTest {
     @Test
     @Transactional
     void ProfileRepository_FindAllFollowersById_ReturnListOfEmpty() {
-        List<Profile> followers = profileRepository.findAllFollowersById(source.getProfileId());
+        Pageable page = new OffsetLimitRequest(0, 1);
+        Page<Profile> followers = profileRepository.findAllFollowersById(source.getProfileId(), page);
 
-        assertTrue(followers.isEmpty());
+        assertTrue(followers.getContent().isEmpty());
     }
 
     @Test
     @Transactional
     void ProfileRepository_FindAllFollowersById_ReturnListOfProfile() {
-        List<Profile> followers = profileRepository.findAllFollowersById(target.getProfileId());
+        Pageable page = new OffsetLimitRequest(0, 1);
+        Page<Profile> followers = profileRepository.findAllFollowersById(target.getProfileId(), page);
 
         assertFalse(followers.isEmpty());
-        assertEquals(1, followers.size());
-        assertEquals(source.getProfileId(), followers.get(0).getProfileId());
+        assertEquals(1, followers.getContent().size());
+        assertEquals(source.getProfileId(), followers.getContent().get(0).getProfileId());
     }
 
     @Test
     @Transactional
     void ProfileRepository_FindAllFollowingById_ReturnListOfEmpty() {
-        List<Profile> following = profileRepository.findAllFollowingById(target.getProfileId());
+        Pageable page = new OffsetLimitRequest(0, 1);
+        Page<Profile> following = profileRepository.findAllFollowingById(target.getProfileId(), page);
 
-        assertTrue(following.isEmpty());
+        assertTrue(following.getContent().isEmpty());
     }
 
     @Test
     @Transactional
     void ProfileRepository_FindAllFollowingById_ReturnListOfProfile() {
-        List<Profile> following = profileRepository.findAllFollowingById(source.getProfileId());
+        Pageable page = new OffsetLimitRequest(0, 1);
+        Page<Profile> following = profileRepository.findAllFollowingById(source.getProfileId(), page);
 
         assertFalse(following.isEmpty());
-        assertEquals(1, following.size());
-        assertEquals(target.getProfileId(), following.get(0).getProfileId());
+        assertEquals(1, following.getContent().size());
+        assertEquals(target.getProfileId(), following.getContent().get(0).getProfileId());
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/mapper/PageMapperTest.java
+++ b/src/test/java/com/example/echo_api/unit/mapper/PageMapperTest.java
@@ -1,0 +1,37 @@
+package com.example.echo_api.unit.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
+
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
+import com.example.echo_api.persistence.mapper.PageMapper;
+import com.example.echo_api.util.pagination.OffsetLimitRequest;
+
+class PageMapperTest {
+
+    @Test
+    void PageMapper_toDTO() {
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable pageable = new OffsetLimitRequest(offset, limit);
+        List<String> content = List.of("test");
+        Page<String> page = new PageImpl<>(content, pageable, 0);
+        PageDTO<String> pageDto = PageMapper.toDTO(page, uri);
+
+        assertNull(pageDto.previous());
+        assertNull(pageDto.next());
+        assertEquals(offset, pageDto.offset());
+        assertEquals(limit, pageDto.limit());
+        assertEquals(content.size(), pageDto.total());
+        assertEquals(content, pageDto.items());
+    }
+
+}

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -241,40 +241,6 @@ class ProfileServiceTest {
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} correctly
-     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
-     * {@link Profile} associated to the {@code username} has no followers.
-     */
-    @Test
-    void ProfileService_GetFollowers_ReturnPageOfEmpty() throws Exception {
-        // arrange
-        String username = "existing-user";
-        Profile testProfile = createTestProfile(username, "test");
-
-        String uri = "/some/api/uri";
-        int offset = 0;
-        int limit = 1;
-        Pageable page = new OffsetLimitRequest(offset, limit);
-
-        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
-        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
-        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
-
-        mockAuthenticatedUser();
-        mockProfileRepository(testProfile);
-        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
-        when(httpRequest.getRequestURI()).thenReturn(uri);
-
-        // act
-        PageDTO<ProfileDTO> actual = profileService.getFollowers(username, page);
-
-        // assert
-        assertTrue(actual.items().isEmpty());
-        assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
-    }
-
-    /**
-     * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} correctly
      * returns a non-empty {@link PageDTO} of {@link ProfileDTO} when the
      * {@link Profile} associated to the {@code username} has at least 1 follower.
      */
@@ -311,6 +277,40 @@ class ProfileServiceTest {
     }
 
     /**
+     * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} correctly
+     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
+     * {@link Profile} associated to the {@code username} has no followers.
+     */
+    @Test
+    void ProfileService_GetFollowers_ReturnPageOfEmpty() throws Exception {
+        // arrange
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
+
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
+        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
+
+        // act
+        PageDTO<ProfileDTO> actual = profileService.getFollowers(username, page);
+
+        // assert
+        assertTrue(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
+    }
+
+    /**
      * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} throws
      * {@link UsernameNotFoundException} when no such profile with the supplied
      * username exists.
@@ -329,40 +329,6 @@ class ProfileServiceTest {
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.getFollowers(username, page));
-    }
-
-    /**
-     * Test ensures that {@link ProfileServiceImpl#getFollowing(String)} correctly
-     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
-     * {@link Profile} associated to the {@code username} has no following.
-     */
-    @Test
-    void ProfileService_GetFollowing_ReturnPageOfEmpty() {
-        // arrange
-        String username = "existing-user";
-        Profile testProfile = createTestProfile(username, "test");
-
-        String uri = "/some/api/uri";
-        int offset = 0;
-        int limit = 1;
-        Pageable page = new OffsetLimitRequest(offset, limit);
-
-        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
-        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
-        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
-
-        mockAuthenticatedUser();
-        mockProfileRepository(testProfile);
-        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
-        when(httpRequest.getRequestURI()).thenReturn(uri);
-
-        // act
-        PageDTO<ProfileDTO> actual = profileService.getFollowing(username, page);
-
-        // assert
-        assertTrue(actual.items().isEmpty());
-        assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
     }
 
     /**
@@ -398,6 +364,40 @@ class ProfileServiceTest {
 
         // assert
         assertFalse(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
+    }
+
+    /**
+     * Test ensures that {@link ProfileServiceImpl#getFollowing(String)} correctly
+     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
+     * {@link Profile} associated to the {@code username} has no following.
+     */
+    @Test
+    void ProfileService_GetFollowing_ReturnPageOfEmpty() {
+        // arrange
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
+
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
+        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
+
+        // act
+        PageDTO<ProfileDTO> actual = profileService.getFollowing(username, page);
+
+        // assert
+        assertTrue(actual.items().isEmpty());
         assertEquals(expected, actual);
         verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
     }

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -3,18 +3,18 @@ package com.example.echo_api.unit.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import com.example.echo_api.config.ErrorMessageConfig;
 import com.example.echo_api.exception.custom.relationship.AlreadyBlockingException;
@@ -25,9 +25,11 @@ import com.example.echo_api.exception.custom.relationship.NotFollowingException;
 import com.example.echo_api.exception.custom.relationship.SelfActionException;
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
+import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.MetricsDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.persistence.dto.response.profile.RelationshipDTO;
+import com.example.echo_api.persistence.mapper.PageMapper;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
 import com.example.echo_api.persistence.model.profile.Profile;
@@ -37,6 +39,9 @@ import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.service.profile.ProfileServiceImpl;
 import com.example.echo_api.service.relationship.RelationshipService;
 import com.example.echo_api.service.session.SessionService;
+import com.example.echo_api.util.pagination.OffsetLimitRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Unit test class for {@link ProfileService}.
@@ -56,22 +61,53 @@ class ProfileServiceTest {
     @Mock
     private ProfileRepository profileRepository;
 
+    @Mock
+    private HttpServletRequest httpRequest;
+
     @InjectMocks
     private ProfileServiceImpl profileService;
 
-    private static Account authenticatedUser;
-    private static Profile me;
+    private final Account authenticatedAccount = new Account("authenticatedUser", "password");
+    private final Profile authenticatedProfile = new Profile(authenticatedAccount);
 
-    @BeforeAll
-    static void setup() throws Exception {
-        authenticatedUser = new Account("me", "test");
-        me = new Profile(authenticatedUser);
+    // ---- helper methods ----
 
-        // set id with reflection
-        Field idField = Profile.class.getDeclaredField("profileId");
-        idField.setAccessible(true);
-        idField.set(me, UUID.randomUUID());
+    private Profile createTestProfile(String username, String password) {
+        Account account = new Account(username, password);
+        return new Profile(account);
     }
+
+    private MetricsDTO createMetricsDto() {
+        return new MetricsDTO(0, 0, 0, 0);
+    }
+
+    private RelationshipDTO createRelationshipDto() {
+        return new RelationshipDTO(false, false, false, false);
+    }
+
+    private ProfileDTO createProfileDto(Profile profile, MetricsDTO metrics, RelationshipDTO relationship) {
+        return ProfileMapper.toDTO(profile, metrics, relationship);
+    }
+
+    private void mockAuthenticatedUser() {
+        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedAccount);
+        when(profileRepository.findByUsername(authenticatedAccount.getUsername()))
+            .thenReturn(Optional.of(authenticatedProfile));
+    }
+
+    private void mockProfileRepository(Profile profile) {
+        when(profileRepository.findByUsername(profile.getUsername())).thenReturn(Optional.of(profile));
+    }
+
+    private void mockMetricsService(Profile profile) {
+        when(profileMetricsService.getMetrics(profile)).thenReturn(createMetricsDto());
+    }
+
+    private void mockRelationshipService(Profile profile) {
+        when(relationshipService.getRelationship(authenticatedProfile, profile)).thenReturn(createRelationshipDto());
+    }
+
+    // ---- tests ----
 
     /**
      * Test ensures that the {@link ProfileServiceImpl#getByUsername(String)} method
@@ -80,26 +116,23 @@ class ProfileServiceTest {
     @Test
     void ProfileService_GetByUsername_ReturnProfileDTO() {
         // arrange
-        Account account = new Account("test", "test");
-        Profile profile = new Profile(account);
-        MetricsDTO metrics = new MetricsDTO(0, 0, 0, 0);
-        RelationshipDTO relationship = new RelationshipDTO(false, false, false, false);
-        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics, relationship);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
+        ProfileDTO expected = createProfileDto(testProfile, createMetricsDto(), createRelationshipDto());
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
-        when(profileMetricsService.getMetrics(profile)).thenReturn(metrics);
-        when(relationshipService.getRelationship(me, profile)).thenReturn(relationship);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        mockMetricsService(testProfile);
+        mockRelationshipService(testProfile);
 
         // act
-        ProfileDTO actual = profileService.getByUsername(profile.getUsername());
+        ProfileDTO actual = profileService.getByUsername(username);
 
         // assert
         assertNotNull(actual);
         assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(profile.getUsername());
+        verify(profileRepository, times(1)).findByUsername(username);
     }
 
     /**
@@ -111,8 +144,9 @@ class ProfileServiceTest {
     void ProfileService_GetByUsername_ThrowUsernameNotFound() {
         // arrange
         String username = "non-existent-user";
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+
+        // mock
+        mockAuthenticatedUser();
         when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
@@ -125,14 +159,13 @@ class ProfileServiceTest {
      * returns the authenticated account's profile.
      */
     @Test
-    void ProfileService_GetMe_ReturnProfileResponse() {
+    void ProfileService_GetMe_ReturnProfileDTO() {
         // arrange
-        MetricsDTO metrics = new MetricsDTO(0, 0, 0, 0);
-        ProfileDTO expected = ProfileMapper.toDTO(me, metrics, null);
+        ProfileDTO expected = createProfileDto(authenticatedProfile, createMetricsDto(), null);
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileMetricsService.getMetrics(me)).thenReturn(metrics);
+        // mock
+        mockAuthenticatedUser();
+        mockMetricsService(authenticatedProfile);
 
         // act
         ProfileDTO actual = profileService.getMe();
@@ -140,8 +173,7 @@ class ProfileServiceTest {
         // assert
         assertNotNull(actual);
         assertEquals(expected, actual);
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
+        verify(profileRepository, times(1)).findByUsername(authenticatedAccount.getUsername());
     }
 
     /**
@@ -150,219 +182,245 @@ class ProfileServiceTest {
      * authenticated account's username exists.
      */
     @Test
-    void ProfileService_GetMe_ThrowUsernameNotFound() {
+    void ProfileService_GetMe_ThrowsUsernameNotFound() {
         // arrange
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.empty());
+        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedAccount);
+        when(profileRepository.findByUsername(authenticatedAccount.getUsername())).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.getMe());
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
+        verify(profileRepository, times(1)).findByUsername(authenticatedAccount.getUsername());
     }
 
     /**
      * Test ensures that the
-     * {@link ProfileServiceImpl#updateMeProfileInfo(UpdateProfileDTO)} method
-     * correctly updates the authenticated account's profile information.
+     * {@link ProfileServiceImpl#updateMeProfile(UpdateProfileDTO)} method correctly
+     * updates the authenticated account's profile information.
      */
     @Test
-    void ProfileService_UpdateMeProfileInfo_ReturnVoid() {
+    void ProfileService_UpdateMeProfile_ReturnVoid() {
         // arrange
         UpdateProfileDTO request = new UpdateProfileDTO(
             "John Doe",
             "Bio",
             "Location");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+        mockAuthenticatedUser();
 
         // act
         profileService.updateMeProfile(request);
 
         // assert
-        assertEquals(request.name(), me.getName());
-        assertEquals(request.bio(), me.getBio());
-        assertEquals(request.location(), me.getLocation());
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
+        assertEquals(request.name(), authenticatedProfile.getName());
+        assertEquals(request.bio(), authenticatedProfile.getBio());
+        assertEquals(request.location(), authenticatedProfile.getLocation());
+        verify(profileRepository, times(1)).findByUsername(authenticatedProfile.getUsername());
     }
 
     /**
      * Test ensures that the
-     * {@link ProfileServiceImpl#updateMeProfileInfo(UpdateProfileDTO)} method
-     * correctly throws a {@link UsernameNotFoundException} when no such profile
-     * with the authenticated account's username exists.
+     * {@link ProfileServiceImpl#updateMeProfile(UpdateProfileDTO)} method correctly
+     * throws a {@link UsernameNotFoundException} when no such profile with the
+     * authenticated account's username exists.
      */
     @Test
-    void ProfileService_UpdateMeProfileInfo_ThrowUsernameNotFound() {
+    void ProfileService_UpdateMeProfile_ThrowUsernameNotFound() {
         // arrange
         UpdateProfileDTO request = new UpdateProfileDTO(
-            "name",
-            "bio",
-            "location");
+            "John Doe",
+            "Bio",
+            "Location");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.empty());
+        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedAccount);
+        when(profileRepository.findByUsername(authenticatedAccount.getUsername())).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.updateMeProfile(request));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
+        verify(profileRepository, times(1)).findByUsername(authenticatedAccount.getUsername());
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} correctly
-     * returns an empty {@link List} of {@link ProfileDTO} when the {@link Profile}
-     * associated to the {@code username} has no followers.
+     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
+     * {@link Profile} associated to the {@code username} has no followers.
      */
     @Test
-    void ProfileService_GetFollowers_ReturnListOfEmpty() {
+    void ProfileService_GetFollowers_ReturnPageOfEmpty() throws Exception {
         // arrange
-        Account account = new Account("test", "test");
-        Profile profile = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
-        when(profileRepository.findAllFollowersById(profile.getProfileId())).thenReturn(new ArrayList<>());
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
+        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
-        List<ProfileDTO> list = profileService.getFollowers(profile.getUsername());
+        PageDTO<ProfileDTO> actual = profileService.getFollowers(username, page);
 
         // assert
-        assertTrue(list.isEmpty());
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(profile.getUsername());
-        verify(profileRepository, times(1)).findAllFollowersById(profile.getProfileId());
+        assertTrue(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} correctly
-     * returns a non-empty {@link List} of {@link ProfileDTO} when the
+     * returns a non-empty {@link PageDTO} of {@link ProfileDTO} when the
      * {@link Profile} associated to the {@code username} has at least 1 follower.
      */
     @Test
-    void ProfileService_GetFollowers_ReturnListOfProfileDto() {
+    void ProfileService_GetFollowers_ReturnPageOfProfileDto() {
         // arrange
-        Account account = new Account("test", "test");
-        Profile profile = new Profile(account);
-        MetricsDTO metrics = new MetricsDTO(0, 0, 0, 0);
-        RelationshipDTO relationship = new RelationshipDTO(false, false, false, false);
-        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics, relationship);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
+        ProfileDTO testProfileDto = createProfileDto(testProfile, createMetricsDto(), createRelationshipDto());
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
-        when(profileRepository.findAllFollowersById(profile.getProfileId())).thenReturn(List.of(profile));
-        when(profileMetricsService.getMetrics(profile)).thenReturn(metrics);
-        when(relationshipService.getRelationship(me, profile)).thenReturn(relationship);
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> followers = new PageImpl<>(List.of(testProfile), page, 0);
+        Page<ProfileDTO> followersDto = new PageImpl<>(List.of(testProfileDto), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(followersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        mockMetricsService(testProfile);
+        mockRelationshipService(testProfile);
+        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(followers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
-        List<ProfileDTO> list = profileService.getFollowers(profile.getUsername());
+        PageDTO<ProfileDTO> actual = profileService.getFollowers(username, page);
 
         // assert
-        assertFalse(list.isEmpty());
-        assertEquals(expected, list.get(0));
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(profile.getUsername());
-        verify(profileRepository, times(1)).findAllFollowersById(profile.getProfileId());
+        assertFalse(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowers(String)} throws
-     * {@link UsernameNotFoundException} when no such profile with the authenticated
-     * account's username exists.
+     * {@link UsernameNotFoundException} when no such profile with the supplied
+     * username exists.
      */
     @Test
     void ProfileService_GetFollowers_ThrowsUsernameNotFound() {
         // arrange
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername("non-existent-username")).thenThrow(new UsernameNotFoundException());
+        String username = "non-existing-user";
+
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        mockAuthenticatedUser();
+        when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(UsernameNotFoundException.class, () -> profileService.getFollowers("non-existent-username"));
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername("non-existent-username");
-        verify(profileRepository, never()).findAllFollowersById(any(UUID.class));
+        assertThrows(UsernameNotFoundException.class, () -> profileService.getFollowers(username, page));
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowing(String)} correctly
-     * returns an empty {@link List} of {@link ProfileDTO} when the {@link Profile}
-     * associated to the {@code username} has no followers.
+     * returns an empty {@link PageDTO} of {@link ProfileDTO} when the
+     * {@link Profile} associated to the {@code username} has no following.
      */
     @Test
-    void ProfileService_GetFollowing_ReturnListOfEmpty() {
+    void ProfileService_GetFollowing_ReturnPageOfEmpty() {
         // arrange
-        Account account = new Account("test", "test");
-        Profile profile = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
-        when(profileRepository.findAllFollowingById(profile.getProfileId())).thenReturn(new ArrayList<>());
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> emptyFollowers = new PageImpl<>(new ArrayList<>(), page, 0);
+        Page<ProfileDTO> emptyFollowersDto = new PageImpl<>(new ArrayList<>(), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(emptyFollowersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
-        List<ProfileDTO> list = profileService.getFollowing(profile.getUsername());
+        PageDTO<ProfileDTO> actual = profileService.getFollowing(username, page);
 
         // assert
-        assertTrue(list.isEmpty());
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(profile.getUsername());
-        verify(profileRepository, times(1)).findAllFollowingById(profile.getProfileId());
+        assertTrue(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowing(String)} correctly
-     * returns a non-empty {@link List} of {@link ProfileDTO} when the
-     * {@link Profile} associated to the {@code username} has at least 1 follower.
+     * returns a non-empty {@link PageDTO} of {@link ProfileDTO} when the
+     * {@link Profile} associated to the {@code username} has at least 1 following.
      */
     @Test
-    void ProfileService_GetFollowing_ReturnListOfProfileDto() {
+    void ProfileService_GetFollowing_ReturnPageOfProfileDto() {
         // arrange
-        Account account = new Account("test", "test");
-        Profile profile = new Profile(account);
-        MetricsDTO metrics = new MetricsDTO(0, 0, 0, 0);
-        RelationshipDTO relationship = new RelationshipDTO(false, false, false, false);
-        ProfileDTO expected = ProfileMapper.toDTO(profile, metrics, relationship);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
+        ProfileDTO testProfileDto = createProfileDto(testProfile, createMetricsDto(), createRelationshipDto());
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(profile));
-        when(profileRepository.findAllFollowingById(profile.getProfileId())).thenReturn(List.of(profile));
-        when(profileMetricsService.getMetrics(profile)).thenReturn(metrics);
-        when(relationshipService.getRelationship(me, profile)).thenReturn(relationship);
+        String uri = "/some/api/uri";
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        Page<Profile> followers = new PageImpl<>(List.of(testProfile), page, 0);
+        Page<ProfileDTO> followersDto = new PageImpl<>(List.of(testProfileDto), page, 0);
+        PageDTO<ProfileDTO> expected = PageMapper.toDTO(followersDto, uri);
+
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        mockMetricsService(testProfile);
+        mockRelationshipService(testProfile);
+        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(followers);
+        when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
-        List<ProfileDTO> list = profileService.getFollowing(profile.getUsername());
+        PageDTO<ProfileDTO> actual = profileService.getFollowing(username, page);
 
         // assert
-        assertFalse(list.isEmpty());
-        assertEquals(expected, list.get(0));
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(profile.getUsername());
-        verify(profileRepository, times(1)).findAllFollowingById(profile.getProfileId());
+        assertFalse(actual.items().isEmpty());
+        assertEquals(expected, actual);
+        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#getFollowing(String)} throws
-     * {@link UsernameNotFoundException} when no such profile with the authenticated
-     * account's username exists.
+     * {@link UsernameNotFoundException} when no such profile with the supplied
+     * username exists.
      */
     @Test
     void ProfileService_GetFollowing_ThrowsUsernameNotFound() {
         // arrange
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername("non-existent-username")).thenThrow(new UsernameNotFoundException());
+        String username = "non-existing-user";
+
+        int offset = 0;
+        int limit = 1;
+        Pageable page = new OffsetLimitRequest(offset, limit);
+
+        mockAuthenticatedUser();
+        when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(UsernameNotFoundException.class, () -> profileService.getFollowing("non-existent-username"));
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername("non-existent-username");
-        verify(profileRepository, never()).findAllFollowersById(any(UUID.class));
+        assertThrows(UsernameNotFoundException.class, () -> profileService.getFollowing(username, page));
     }
 
     /**
@@ -372,20 +430,17 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Follow_ReturnVoid() {
         // arrange
-        Account account = new Account("test", "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(account.getUsername())).thenReturn(Optional.of(target));
-        doNothing().when(relationshipService).follow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doNothing().when(relationshipService).follow(authenticatedProfile, testProfile);
 
         // act & assert
-        assertDoesNotThrow(() -> profileService.follow(account.getUsername()));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(account.getUsername());
-        verify(relationshipService, times(1)).follow(me, target);
+        assertDoesNotThrow(() -> profileService.follow(username));
+        verify(relationshipService, times(1)).follow(authenticatedProfile, testProfile);
     }
 
     /**
@@ -395,95 +450,79 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Follow_Throw400UsernameNotFoundException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "non-existent-user";
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+        // mock
+        mockAuthenticatedUser();
         when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.follow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
         verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, never()).follow(me, target);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#follow(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is equal to the
+     * {@link SelfActionException} when the supplied username is equal to the
      * current authenticated user.
      */
     @Test
     void ProfileService_Follow_ThrowSelfActionException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new SelfActionException(ErrorMessageConfig.SELF_FOLLOW)).when(relationshipService).follow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new SelfActionException(ErrorMessageConfig.SELF_FOLLOW)).when(relationshipService)
+            .follow(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(SelfActionException.class, () -> profileService.follow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(account.getUsername());
-        verify(relationshipService, times(1)).follow(me, target);
+        verify(relationshipService, times(1)).follow(authenticatedProfile, testProfile);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#follow(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is already
+     * {@link AlreadyFollowingException} when the supplied username is already
      * followed by the authenticated user.
      */
     @Test
     void ProfileService_Follow_ThrowAlreadyFollowingException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new AlreadyFollowingException()).when(relationshipService).follow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new AlreadyFollowingException()).when(relationshipService).follow(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(AlreadyFollowingException.class, () -> profileService.follow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(account.getUsername());
-        verify(relationshipService, times(1)).follow(me, target);
+        verify(relationshipService, times(1)).follow(authenticatedProfile, testProfile);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#follow(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is blocking the
+     * {@link BlockedException} when the supplied username is blocking the
      * authenticated user.
      */
     @Test
     void ProfileService_Follow_ThrowBlockedException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new BlockedException()).when(relationshipService).follow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new BlockedException()).when(relationshipService).follow(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(BlockedException.class, () -> profileService.follow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).follow(me, target);
+        verify(relationshipService, times(1)).follow(authenticatedProfile, testProfile);
     }
 
     /**
@@ -493,21 +532,17 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Unfollow_ReturnVoid() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doNothing().when(relationshipService).unfollow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doNothing().when(relationshipService).unfollow(authenticatedProfile, testProfile);
 
         // act & assert
         assertDoesNotThrow(() -> profileService.unfollow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).unfollow(me, target);
+        verify(relationshipService, times(1)).unfollow(authenticatedProfile, testProfile);
     }
 
     /**
@@ -517,71 +552,58 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Unfollow_Throw400UsernameNotFound() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "non-existent-user";
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+        // mock
+        mockAuthenticatedUser();
         when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.unfollow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
         verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, never()).unfollow(me, target);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#unfollow(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is equal to the
+     * {@link SelfActionException} when the supplied username is equal to the
      * current authenticated user.
      */
     @Test
     void ProfileService_Unfollow_ThrowSelfActionException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new SelfActionException(ErrorMessageConfig.SELF_UNFOLLOW)).when(relationshipService).unfollow(me,
-            target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new SelfActionException(ErrorMessageConfig.SELF_FOLLOW)).when(relationshipService)
+            .unfollow(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(SelfActionException.class, () -> profileService.unfollow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).unfollow(me, target);
+        verify(relationshipService, times(1)).unfollow(authenticatedProfile, testProfile);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#unfollow(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is already
+     * {@link NotFollowingException} when the supplied username is not already
      * followed by the authenticated user.
      */
     @Test
     void ProfileService_Unfollow_ThrowNotFollowingException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new NotFollowingException()).when(relationshipService).unfollow(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new NotFollowingException()).when(relationshipService).unfollow(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(NotFollowingException.class, () -> profileService.unfollow(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).unfollow(me, target);
+        verify(relationshipService, times(1)).unfollow(authenticatedProfile, testProfile);
     }
 
     /**
@@ -591,21 +613,17 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Block_ReturnVoid() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doNothing().when(relationshipService).block(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doNothing().when(relationshipService).block(authenticatedProfile, testProfile);
 
         // act & assert
         assertDoesNotThrow(() -> profileService.block(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).block(me, target);
+        verify(relationshipService, times(1)).block(authenticatedProfile, testProfile);
     }
 
     /**
@@ -615,70 +633,58 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Block_Throw400UsernameNotFound() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "non-existent-user";
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+        // mock
+        mockAuthenticatedUser();
         when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.block(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
         verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, never()).block(me, target);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#block(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is equal to the
+     * {@link SelfActionException} when the supplied username is equal to the
      * current authenticated user.
      */
     @Test
     void ProfileService_Block_ThrowSelfActionException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new SelfActionException(ErrorMessageConfig.SELF_BLOCK)).when(relationshipService).block(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new SelfActionException(ErrorMessageConfig.SELF_FOLLOW)).when(relationshipService)
+            .block(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(SelfActionException.class, () -> profileService.block(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).block(me, target);
+        verify(relationshipService, times(1)).block(authenticatedProfile, testProfile);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#block(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is already
-     * followed by the authenticated user.
+     * {@link AlreadyBlockingException} when the supplied username is already
+     * blocked by the authenticated user.
      */
     @Test
     void ProfileService_Block_ThrowAlreadyBlockingException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new AlreadyBlockingException()).when(relationshipService).block(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new AlreadyBlockingException()).when(relationshipService).block(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(AlreadyBlockingException.class, () -> profileService.block(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).block(me, target);
+        verify(relationshipService, times(1)).block(authenticatedProfile, testProfile);
     }
 
     /**
@@ -688,21 +694,17 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Unblock_ReturnVoid() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doNothing().when(relationshipService).unblock(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doNothing().when(relationshipService).unblock(authenticatedProfile, testProfile);
 
         // act & assert
         assertDoesNotThrow(() -> profileService.unblock(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).unblock(me, target);
+        verify(relationshipService, times(1)).unblock(authenticatedProfile, testProfile);
     }
 
     /**
@@ -712,70 +714,58 @@ class ProfileServiceTest {
     @Test
     void ProfileService_Unblock_Throw400UsernameNotFound() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "non-existent-user";
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
+        // mock
+        mockAuthenticatedUser();
         when(profileRepository.findByUsername(username)).thenReturn(Optional.empty());
 
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.unblock(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
         verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, never()).unblock(me, target);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#unblock(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is equal to the
+     * {@link SelfActionException} when the supplied username is equal to the
      * current authenticated user.
      */
     @Test
     void ProfileService_Unblock_ThrowSelfActionException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new SelfActionException(ErrorMessageConfig.SELF_BLOCK)).when(relationshipService).unblock(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new SelfActionException(ErrorMessageConfig.SELF_FOLLOW)).when(relationshipService)
+            .unblock(authenticatedProfile, testProfile);
 
         // act & assert
         assertThrows(SelfActionException.class, () -> profileService.unblock(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).unblock(me, target);
+        verify(relationshipService, times(1)).unblock(authenticatedProfile, testProfile);
     }
 
     /**
      * Test ensures that {@link ProfileServiceImpl#unblock(String)} throws
-     * {@link UsernameNotFoundException} when the supplied username is already
-     * followed by the authenticated user.
+     * {@link NotBlockingException} when the supplied username is already not
+     * already blocked by the authenticated user.
      */
     @Test
     void ProfileService_Unblock_ThrowNotBlockingException() {
         // arrange
-        String username = "valid-username";
-        Account account = new Account(username, "test");
-        Profile target = new Profile(account);
+        String username = "existing-user";
+        Profile testProfile = createTestProfile(username, "test");
 
-        when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(authenticatedUser.getUsername())).thenReturn(Optional.of(me));
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(target));
-        doThrow(new NotBlockingException()).when(relationshipService).block(me, target);
+        // mock
+        mockAuthenticatedUser();
+        mockProfileRepository(testProfile);
+        doThrow(new NotBlockingException()).when(relationshipService).unblock(authenticatedProfile, testProfile);
 
         // act & assert
-        assertThrows(NotBlockingException.class, () -> profileService.block(username));
-        verify(sessionService, times(1)).getAuthenticatedUser();
-        verify(profileRepository, times(1)).findByUsername(authenticatedUser.getUsername());
-        verify(profileRepository, times(1)).findByUsername(username);
-        verify(relationshipService, times(1)).block(me, target);
+        assertThrows(NotBlockingException.class, () -> profileService.unblock(username));
+        verify(relationshipService, times(1)).unblock(authenticatedProfile, testProfile);
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/validation/LimitAnnotationTest.java
+++ b/src/test/java/com/example/echo_api/unit/validation/LimitAnnotationTest.java
@@ -1,0 +1,74 @@
+package com.example.echo_api.unit.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.example.echo_api.validation.pagination.annotations.Limit;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+/**
+ * Unit test class for {@link Limit} annotation.
+ */
+class LimitAnnotationTest {
+
+    private static Validator validator;
+
+    // Dummy class for validation
+    static class TestLimit {
+
+        @Limit
+        private int limit;
+
+        public TestLimit(int limit) {
+            this.limit = limit;
+        }
+
+    }
+
+    @BeforeAll
+    static void setup() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    /**
+     * Test ensures that the {@link Limit} annotation does not return a constraint
+     * violation for all 5 items present in {@code limits}.
+     */
+    @Test
+    void validLimitsShouldPass() {
+        List<Integer> limits = List.of(1, 5, 10, 25, 50);
+
+        for (int limit : limits) {
+            TestLimit test = new TestLimit(limit);
+            Set<ConstraintViolation<TestLimit>> violations = validator.validate(test);
+
+            assertTrue(violations.isEmpty(), "Valid limit failed validation: " + limit);
+        }
+    }
+
+    /**
+     * Test ensures that the {@link Limit} annotation returns a constraint violation
+     * for all 5 items present in {@code limits}.
+     */
+    @Test
+    void invalidLimitsShouldFail() {
+        List<Integer> limits = List.of(-10000, -50, 0, 51, 10000);
+
+        for (int limit : limits) {
+            TestLimit test = new TestLimit(limit);
+            Set<ConstraintViolation<TestLimit>> violations = validator.validate(test);
+
+            assertFalse(violations.isEmpty(), "Invalid limit passed validation: " + limit);
+        }
+    }
+
+}

--- a/src/test/java/com/example/echo_api/unit/validation/OffsetAnnotationTest.java
+++ b/src/test/java/com/example/echo_api/unit/validation/OffsetAnnotationTest.java
@@ -1,0 +1,74 @@
+package com.example.echo_api.unit.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.example.echo_api.validation.pagination.annotations.Offset;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+/**
+ * Unit test class for {@link Offset} annotation.
+ */
+class OffsetAnnotationTest {
+
+    private static Validator validator;
+
+    // Dummy class for validation
+    static class TestOffset {
+
+        @Offset
+        private int offset;
+
+        public TestOffset(int offset) {
+            this.offset = offset;
+        }
+
+    }
+
+    @BeforeAll
+    static void setup() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    /**
+     * Test ensures that the {@link Offset} annotation does not return a constraint
+     * violation for all 5 items present in {@code offsets}.
+     */
+    @Test
+    void validOffsetsShouldPass() {
+        List<Integer> offsets = List.of(0, 10, 25, 50, 10000);
+
+        for (int offset : offsets) {
+            TestOffset test = new TestOffset(offset);
+            Set<ConstraintViolation<TestOffset>> violations = validator.validate(test);
+
+            assertTrue(violations.isEmpty(), "Valid offset failed validation: " + offset);
+        }
+    }
+
+    /**
+     * Test ensures that the {@link Offset} annotation returns a constraint
+     * violation for all 5 items present in {@code offsets}.
+     */
+    @Test
+    void invalidOffsetsShouldFail() {
+        List<Integer> offsets = List.of(-10000, -50, -25, -10, -1);
+
+        for (int offset : offsets) {
+            TestOffset test = new TestOffset(offset);
+            Set<ConstraintViolation<TestOffset>> violations = validator.validate(test);
+
+            assertFalse(violations.isEmpty(), "Invalid offset passed validation: " + offset);
+        }
+    }
+
+}


### PR DESCRIPTION
## Purpose
PR introduces pagination to the application. The pagination structure is similar to that of the Spotify Web API ([see example](https://developer.spotify.com/documentation/web-api/reference/get-users-saved-albums)).

### Example usage

The usage of pagination requires query parameters for `offset` and `limit` to be specified as a suffix to any paginated endpoint. 

`offset` integer (default: `0`)
`imit` integer (default: `20`, range: `0` - `50`)

Example: `GET /api/v1/some/endpoint?offset=0&limit=20`

### Pagination response structure

```
{
    "previous": String | null,
    "next": String | null,
    "offset": int,
    "limit": int,
    "total": int,
    "items": Object[]
}
```

### Affected endpoints

Pagination is now supported via these endpoints.

`GET /api/v1/profile/{username}/followers`
`GET /api/v1/profile/{username}/following`

## Changelog
- Added `OffsetLimitRequest` as a custom `Pageable` implementation to support `offset` and `limit` pagination
- Refactored `ProfileController.getFollowers` `ProfileController.getFollowing` to accept query parameters `offset` and `limit` and convert to a `Pageable` of type `OffsetLimitRequest`
- Refactored `ProfileRepository` to implement `PagingAndSortingRepository<Profile, UUID>`
- Refactored `ProfileRepository.findAllFollowersById` `ProfileRepository.findAllFollowingById` to accept `UUID, Pageable` and return type `Page<Profile>`
- Added `PageDTO` as a custom response type for pagination
- Added `PageMapper.toDTO` to map `Page<T> page, String uri` to the custom `PageDTO` response type 
- Refactored `ProfileService.getFollowers` `ProfileService.getFollowing` to implement custom pagination
- Added custom validation annotations `@Offset` and `@Limit` to validate any supplied `int offset` and `int limit` to controller methods
- Refactored relevant `ProfileService` unit tests to account for paginated objects
- Added additional `ProfileController` unit tests for `getFollowers` `getFollowing` methods
- Added additional `ProfileController` integration tests for `getFollowers` `getFollowing` methods
- Added `PageMapper` unit tests
- Added `OffsetAnnotation` and `LimitAnnotation` unit tests