### PR TITLE
refactor: profile id variable name

### DIFF
--- a/src/main/java/com/example/echo_api/persistence/model/account/Account.java
+++ b/src/main/java/com/example/echo_api/persistence/model/account/Account.java
@@ -35,13 +35,9 @@ public class Account implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    // ---- primary keys / foreign keys ----
-
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-
-    // ---- entity-specific attributes ----
 
     @Username
     private String username;

--- a/src/main/java/com/example/echo_api/persistence/model/block/Block.java
+++ b/src/main/java/com/example/echo_api/persistence/model/block/Block.java
@@ -36,8 +36,8 @@ public class Block {
     private LocalDateTime createdAt;
 
     public Block(Profile blocker, Profile blocking) {
-        this.blockerId = blocker.getProfileId();
-        this.blockingId = blocking.getProfileId();
+        this.blockerId = blocker.getId();
+        this.blockingId = blocking.getId();
     }
 
 }

--- a/src/main/java/com/example/echo_api/persistence/model/follow/Follow.java
+++ b/src/main/java/com/example/echo_api/persistence/model/follow/Follow.java
@@ -36,8 +36,8 @@ public class Follow {
     private LocalDateTime createdAt;
 
     public Follow(Profile follower, Profile following) {
-        this.followerId = follower.getProfileId();
-        this.followingId = following.getProfileId();
+        this.followerId = follower.getId();
+        this.followingId = following.getId();
     }
 
 }

--- a/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
+++ b/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
@@ -25,17 +25,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Profile {
 
-    // ---- primary keys / foreign keys ----
-
     @Id
     @Column(name = "profile_id", unique = true, nullable = false)
-    private UUID profileId; // PK, FK
+    private UUID id; // PK, FK
 
     @Username
     @Column(unique = true, nullable = false)
     private String username; // FK
-
-    // ---- entity-specific attributes ----
 
     private String name;
 
@@ -60,7 +56,7 @@ public class Profile {
     // ---- constructors ----
 
     public Profile(Account account) {
-        this.profileId = account.getId();
+        this.id = account.getId();
         this.username = account.getUsername();
     }
 

--- a/src/main/java/com/example/echo_api/service/metrics/profile/ProfileMetricsServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/metrics/profile/ProfileMetricsServiceImpl.java
@@ -21,8 +21,8 @@ public class ProfileMetricsServiceImpl implements ProfileMetricsService {
 
     @Override
     public MetricsDTO getMetrics(Profile profile) {
-        int followers = followRepository.countFollowers(profile.getProfileId());
-        int following = followRepository.countFollowing(profile.getProfileId());
+        int followers = followRepository.countFollowers(profile.getId());
+        int following = followRepository.countFollowing(profile.getId());
         int posts = 0; // no posts implementation available
         int media = 0; // no media implementation available
         return new MetricsDTO(followers, following, posts, media);

--- a/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileServiceImpl.java
@@ -68,7 +68,7 @@ public class ProfileServiceImpl implements ProfileService {
     public PageDTO<ProfileDTO> getFollowers(String username, Pageable page) throws UsernameNotFoundException {
         Profile me = findMe();
         Profile target = findByUsername(username);
-        Page<Profile> followersPage = profileRepository.findAllFollowersById(target.getProfileId(), page);
+        Page<Profile> followersPage = profileRepository.findAllFollowersById(target.getId(), page);
 
         Page<ProfileDTO> followersDtoPage = followersPage.map(profile -> ProfileMapper.toDTO(
             profile,
@@ -83,7 +83,7 @@ public class ProfileServiceImpl implements ProfileService {
     public PageDTO<ProfileDTO> getFollowing(String username, Pageable page) throws UsernameNotFoundException {
         Profile me = findMe();
         Profile target = findByUsername(username);
-        Page<Profile> followingPage = profileRepository.findAllFollowingById(target.getProfileId(), page);
+        Page<Profile> followingPage = profileRepository.findAllFollowingById(target.getId(), page);
 
         Page<ProfileDTO> followingDtoPage = followingPage.map(profile -> ProfileMapper.toDTO(
             profile,

--- a/src/main/java/com/example/echo_api/service/relationship/RelationshipServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/relationship/RelationshipServiceImpl.java
@@ -87,7 +87,7 @@ public class RelationshipServiceImpl implements RelationshipService {
      * @return Boolean indicating whether the profiles are a match.
      */
     private boolean isSelfAction(Profile source, Profile target) {
-        return Objects.equals(source.getProfileId(), target.getProfileId());
+        return Objects.equals(source.getId(), target.getId());
     }
 
     /**

--- a/src/main/java/com/example/echo_api/service/relationship/block/BlockServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/relationship/block/BlockServiceImpl.java
@@ -53,7 +53,7 @@ public class BlockServiceImpl implements BlockService {
 
     @Override
     public boolean isBlocking(Profile source, Profile target) {
-        return blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        return blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId());
     }
 
     @Override
@@ -69,7 +69,7 @@ public class BlockServiceImpl implements BlockService {
      * @return Boolean indicating whether the profiles are a match.
      */
     private boolean isSelfAction(Profile source, Profile target) {
-        return Objects.equals(source.getProfileId(), target.getProfileId());
+        return Objects.equals(source.getId(), target.getId());
     }
 
 }

--- a/src/main/java/com/example/echo_api/service/relationship/follow/FollowServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/relationship/follow/FollowServiceImpl.java
@@ -56,7 +56,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public boolean isFollowing(Profile source, Profile target) {
-        return followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId());
+        return followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId());
     }
 
     @Override
@@ -72,7 +72,7 @@ public class FollowServiceImpl implements FollowService {
      * @return Boolean indicating whether the profiles are a match.
      */
     private boolean isSelfAction(Profile source, Profile target) {
-        return Objects.equals(source.getProfileId(), target.getProfileId());
+        return Objects.equals(source.getId(), target.getId());
     }
 
 }

--- a/src/test/java/com/example/echo_api/integration/repository/BlockRepositoryIT.java
+++ b/src/test/java/com/example/echo_api/integration/repository/BlockRepositoryIT.java
@@ -65,7 +65,7 @@ class BlockRepositoryIT extends RepositoryTest {
      */
     @Test
     void BlockRepository_ExistsByBlockerIdAndBlockingId_ReturnTrue() {
-        boolean exists = blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        boolean exists = blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId());
 
         assertTrue(exists);
     }

--- a/src/test/java/com/example/echo_api/integration/repository/FollowRepositoryIT.java
+++ b/src/test/java/com/example/echo_api/integration/repository/FollowRepositoryIT.java
@@ -65,8 +65,8 @@ class FollowRepositoryIT extends RepositoryTest {
      */
     @Test
     void FollowRepository_ExistsByFollowerIdAndFollowingId_ReturnTrue() {
-        boolean exists = followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        boolean exists = followRepository.existsByFollowerIdAndFollowingId(source.getId(),
+            target.getId());
 
         assertTrue(exists);
     }
@@ -91,7 +91,7 @@ class FollowRepositoryIT extends RepositoryTest {
      */
     @Test
     void FollowRepository_CountFollowers_Return0() {
-        int followers = followRepository.countFollowers(source.getProfileId());
+        int followers = followRepository.countFollowers(source.getId());
         assertEquals(0, followers);
     }
 
@@ -101,7 +101,7 @@ class FollowRepositoryIT extends RepositoryTest {
      */
     @Test
     void FollowRepository_CountFollowers_Return1() {
-        int followers = followRepository.countFollowers(target.getProfileId());
+        int followers = followRepository.countFollowers(target.getId());
         assertEquals(1, followers);
     }
 
@@ -111,7 +111,7 @@ class FollowRepositoryIT extends RepositoryTest {
      */
     @Test
     void FollowRepository_CountFollowing_Return0() {
-        int following = followRepository.countFollowing(target.getProfileId());
+        int following = followRepository.countFollowing(target.getId());
         assertEquals(0, following);
     }
 
@@ -121,7 +121,7 @@ class FollowRepositoryIT extends RepositoryTest {
      */
     @Test
     void FollowRepository_CountFollowing_Return1() {
-        int following = followRepository.countFollowing(source.getProfileId());
+        int following = followRepository.countFollowing(source.getId());
         assertEquals(1, following);
     }
 

--- a/src/test/java/com/example/echo_api/integration/repository/ProfileRepositoryIT.java
+++ b/src/test/java/com/example/echo_api/integration/repository/ProfileRepositoryIT.java
@@ -88,7 +88,7 @@ class ProfileRepositoryIT extends RepositoryTest {
     @Transactional
     void ProfileRepository_FindAllFollowersById_ReturnListOfEmpty() {
         Pageable page = new OffsetLimitRequest(0, 1);
-        Page<Profile> followers = profileRepository.findAllFollowersById(source.getProfileId(), page);
+        Page<Profile> followers = profileRepository.findAllFollowersById(source.getId(), page);
 
         assertTrue(followers.getContent().isEmpty());
     }
@@ -97,18 +97,18 @@ class ProfileRepositoryIT extends RepositoryTest {
     @Transactional
     void ProfileRepository_FindAllFollowersById_ReturnListOfProfile() {
         Pageable page = new OffsetLimitRequest(0, 1);
-        Page<Profile> followers = profileRepository.findAllFollowersById(target.getProfileId(), page);
+        Page<Profile> followers = profileRepository.findAllFollowersById(target.getId(), page);
 
         assertFalse(followers.isEmpty());
         assertEquals(1, followers.getContent().size());
-        assertEquals(source.getProfileId(), followers.getContent().get(0).getProfileId());
+        assertEquals(source.getId(), followers.getContent().get(0).getId());
     }
 
     @Test
     @Transactional
     void ProfileRepository_FindAllFollowingById_ReturnListOfEmpty() {
         Pageable page = new OffsetLimitRequest(0, 1);
-        Page<Profile> following = profileRepository.findAllFollowingById(target.getProfileId(), page);
+        Page<Profile> following = profileRepository.findAllFollowingById(target.getId(), page);
 
         assertTrue(following.getContent().isEmpty());
     }
@@ -117,11 +117,11 @@ class ProfileRepositoryIT extends RepositoryTest {
     @Transactional
     void ProfileRepository_FindAllFollowingById_ReturnListOfProfile() {
         Pageable page = new OffsetLimitRequest(0, 1);
-        Page<Profile> following = profileRepository.findAllFollowingById(source.getProfileId(), page);
+        Page<Profile> following = profileRepository.findAllFollowingById(source.getId(), page);
 
         assertFalse(following.isEmpty());
         assertEquals(1, following.getContent().size());
-        assertEquals(target.getProfileId(), following.getContent().get(0).getProfileId());
+        assertEquals(target.getId(), following.getContent().get(0).getId());
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/service/BlockServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/BlockServiceTest.java
@@ -47,7 +47,7 @@ class BlockServiceTest {
         target = new Profile(targetAcc);
 
         // set ids with reflection
-        Field idField = Profile.class.getDeclaredField("profileId");
+        Field idField = Profile.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(source, UUID.randomUUID());
         idField.set(target, UUID.randomUUID());

--- a/src/test/java/com/example/echo_api/unit/service/BlockServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/BlockServiceTest.java
@@ -60,12 +60,11 @@ class BlockServiceTest {
     @Test
     void BlockService_Block_ReturnVoid() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(false);
 
         // act & assert
         assertDoesNotThrow(() -> blockService.block(source, target));
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(1)).save(any(Block.class));
     }
 
@@ -77,7 +76,7 @@ class BlockServiceTest {
     void BlockService_Block_ThrowSelfActionException() {
         // act & assert
         assertThrows(SelfActionException.class, () -> blockService.block(source, source));
-        verify(blockRepository, times(0)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(0)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(0)).save(any(Block.class));
     }
 
@@ -89,12 +88,11 @@ class BlockServiceTest {
     @Test
     void BlockService_Block_ThrowAlreadyBlockingException() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(true);
 
         // act & assert
         assertThrows(AlreadyBlockingException.class, () -> blockService.block(source, target));
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(0)).save(any(Block.class));
     }
 
@@ -105,12 +103,11 @@ class BlockServiceTest {
     @Test
     void BlockService_Unblock_ReturnVoid() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(true);
 
         // act & assert
         assertDoesNotThrow(() -> blockService.unblock(source, target));
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(1)).delete(any(Block.class));
     }
 
@@ -122,7 +119,7 @@ class BlockServiceTest {
     void BlockService_Unblock_ThrowSelfActionException() {
         // act & assert
         assertThrows(SelfActionException.class, () -> blockService.unblock(source, source));
-        verify(blockRepository, times(0)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(0)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(0)).delete(any(Block.class));
     }
 
@@ -134,12 +131,11 @@ class BlockServiceTest {
     @Test
     void BlockService_Unblock_ThrowNotBlockingException() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(false);
 
         // act & assert
         assertThrows(NotBlockingException.class, () -> blockService.unblock(source, target));
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
         verify(blockRepository, times(0)).delete(any(Block.class));
     }
 
@@ -150,15 +146,14 @@ class BlockServiceTest {
     @Test
     void BlockService_IsBlocking_ReturnTrue() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(true);
 
         // act
         boolean isBlocking = blockService.isBlocking(source, target);
 
         // assert
         assertTrue(isBlocking);
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
     }
 
     /**
@@ -168,15 +163,14 @@ class BlockServiceTest {
     @Test
     void BlockService_IsBlocking_ReturnFalse() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(blockRepository.existsByBlockerIdAndBlockingId(source.getId(), target.getId())).thenReturn(false);
 
         // act
         boolean isBlocking = blockService.isBlocking(source, target);
 
         // assert
         assertFalse(isBlocking);
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getProfileId(), target.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(source.getId(), target.getId());
     }
 
     /**
@@ -187,15 +181,14 @@ class BlockServiceTest {
     @Test
     void BlockService_IsBlockedBy_ReturnTrue() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(target.getProfileId(), source.getProfileId()))
-            .thenReturn(true);
+        when(blockRepository.existsByBlockerIdAndBlockingId(target.getId(), source.getId())).thenReturn(true);
 
         // act
         boolean isBlockedBy = blockService.isBlockedBy(source, target);
 
         // assert
         assertTrue(isBlockedBy);
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(target.getProfileId(), source.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(target.getId(), source.getId());
     }
 
     /**
@@ -205,15 +198,14 @@ class BlockServiceTest {
     @Test
     void BlockService_IsBlockedBy_ReturnFalse() {
         // arrange
-        when(blockRepository.existsByBlockerIdAndBlockingId(target.getProfileId(), source.getProfileId()))
-            .thenReturn(false);
+        when(blockRepository.existsByBlockerIdAndBlockingId(target.getId(), source.getId())).thenReturn(false);
 
         // act
         boolean isBlockedBy = blockService.isBlockedBy(source, target);
 
         // assert
         assertFalse(isBlockedBy);
-        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(target.getProfileId(), source.getProfileId());
+        verify(blockRepository, times(1)).existsByBlockerIdAndBlockingId(target.getId(), source.getId());
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/service/FollowServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/FollowServiceTest.java
@@ -60,13 +60,11 @@ class FollowServiceTest {
     @Test
     void FollowService_Follow_ReturnVoid() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(false);
 
         // act & assert
         assertDoesNotThrow(() -> followService.follow(source, target));
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(1)).save(any(Follow.class));
     }
 
@@ -78,8 +76,7 @@ class FollowServiceTest {
     void FollowService_Follow_ThrowSelfActionException() {
         // act & assert
         assertThrows(SelfActionException.class, () -> followService.follow(source, source));
-        verify(followRepository, times(0)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(0)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -91,13 +88,11 @@ class FollowServiceTest {
     @Test
     void FollowService_Follow_ThrowAlreadyFollowingException() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(true);
 
         // act & assert
         assertThrows(AlreadyFollowingException.class, () -> followService.follow(source, target));
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -108,13 +103,11 @@ class FollowServiceTest {
     @Test
     void FollowService_Unfollow_ReturnVoid() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(true);
 
         // act & assert
         assertDoesNotThrow(() -> followService.unfollow(source, target));
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(1)).delete(any(Follow.class));
     }
 
@@ -126,8 +119,7 @@ class FollowServiceTest {
     void FollowService_Unfollow_ThrowSelfActionException() {
         // act & assert
         assertThrows(SelfActionException.class, () -> followService.unfollow(source, source));
-        verify(followRepository, times(0)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(0)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(0)).delete(any(Follow.class));
     }
 
@@ -139,13 +131,11 @@ class FollowServiceTest {
     @Test
     void FollowService_Unfollow_ThrowNotFollowingException() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(false);
 
         // act & assert
         assertThrows(NotFollowingException.class, () -> followService.unfollow(source, target));
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
         verify(followRepository, times(0)).delete(any(Follow.class));
     }
 
@@ -156,16 +146,14 @@ class FollowServiceTest {
     @Test
     void FollowService_IsFollowing_ReturnTrue() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(true);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(true);
 
         // act
         boolean isFollowing = followService.isFollowing(source, target);
 
         // assert
         assertTrue(isFollowing);
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
     }
 
     /**
@@ -175,16 +163,14 @@ class FollowServiceTest {
     @Test
     void FollowService_IsFollowing_ReturnFalse() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(source.getProfileId(), target.getProfileId()))
-            .thenReturn(false);
+        when(followRepository.existsByFollowerIdAndFollowingId(source.getId(), target.getId())).thenReturn(false);
 
         // act
         boolean isFollowing = followService.isFollowing(source, target);
 
         // assert
         assertFalse(isFollowing);
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getProfileId(),
-            target.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(source.getId(), target.getId());
     }
 
     /**
@@ -195,16 +181,14 @@ class FollowServiceTest {
     @Test
     void FollowService_IsFollowedBy_ReturnTrue() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(target.getProfileId(), source.getProfileId()))
-            .thenReturn(true);
+        when(followRepository.existsByFollowerIdAndFollowingId(target.getId(), source.getId())).thenReturn(true);
 
         // act
         boolean isFollowedBy = followService.isFollowedBy(source, target);
 
         // assert
         assertTrue(isFollowedBy);
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(target.getProfileId(),
-            source.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(target.getId(), source.getId());
     }
 
     /**
@@ -214,16 +198,14 @@ class FollowServiceTest {
     @Test
     void FollowService_IsFollowedBy_ReturnFalse() {
         // arrange
-        when(followRepository.existsByFollowerIdAndFollowingId(target.getProfileId(), source.getProfileId()))
-            .thenReturn(false);
+        when(followRepository.existsByFollowerIdAndFollowingId(target.getId(), source.getId())).thenReturn(false);
 
         // act
         boolean isFollowedBy = followService.isFollowedBy(source, target);
 
         // assert
         assertFalse(isFollowedBy);
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(target.getProfileId(),
-            source.getProfileId());
+        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(target.getId(), source.getId());
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/service/FollowServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/FollowServiceTest.java
@@ -47,7 +47,7 @@ class FollowServiceTest {
         target = new Profile(targetAcc);
 
         // set ids with reflection
-        Field idField = Profile.class.getDeclaredField("profileId");
+        Field idField = Profile.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(source, UUID.randomUUID());
         idField.set(target, UUID.randomUUID());

--- a/src/test/java/com/example/echo_api/unit/service/ProfileMetricsServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileMetricsServiceTest.java
@@ -41,7 +41,7 @@ class ProfileMetricsServiceTest {
         profile = new Profile(account);
 
         // set id with reflection
-        Field idField = Profile.class.getDeclaredField("profileId");
+        Field idField = Profile.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(profile, UUID.randomUUID());
     }

--- a/src/test/java/com/example/echo_api/unit/service/ProfileMetricsServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileMetricsServiceTest.java
@@ -51,8 +51,8 @@ class ProfileMetricsServiceTest {
         // arrange
         MetricsDTO expected = new MetricsDTO(0, 0, 0, 0);
 
-        when(followRepository.countFollowers(profile.getProfileId())).thenReturn(0);
-        when(followRepository.countFollowing(profile.getProfileId())).thenReturn(0);
+        when(followRepository.countFollowers(profile.getId())).thenReturn(0);
+        when(followRepository.countFollowing(profile.getId())).thenReturn(0);
 
         // act
         MetricsDTO actual = profileMetricsService.getMetrics(profile);

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -264,7 +264,7 @@ class ProfileServiceTest {
         mockProfileRepository(testProfile);
         mockMetricsService(testProfile);
         mockRelationshipService(testProfile);
-        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(followers);
+        when(profileRepository.findAllFollowersById(testProfile.getId(), page)).thenReturn(followers);
         when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
@@ -273,7 +273,7 @@ class ProfileServiceTest {
         // assert
         assertFalse(actual.items().isEmpty());
         assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
+        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getId(), page);
     }
 
     /**
@@ -298,7 +298,7 @@ class ProfileServiceTest {
 
         mockAuthenticatedUser();
         mockProfileRepository(testProfile);
-        when(profileRepository.findAllFollowersById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(profileRepository.findAllFollowersById(testProfile.getId(), page)).thenReturn(emptyFollowers);
         when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
@@ -307,7 +307,7 @@ class ProfileServiceTest {
         // assert
         assertTrue(actual.items().isEmpty());
         assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getProfileId(), page);
+        verify(profileRepository, times(1)).findAllFollowersById(testProfile.getId(), page);
     }
 
     /**
@@ -356,7 +356,7 @@ class ProfileServiceTest {
         mockProfileRepository(testProfile);
         mockMetricsService(testProfile);
         mockRelationshipService(testProfile);
-        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(followers);
+        when(profileRepository.findAllFollowingById(testProfile.getId(), page)).thenReturn(followers);
         when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
@@ -365,7 +365,7 @@ class ProfileServiceTest {
         // assert
         assertFalse(actual.items().isEmpty());
         assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
+        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getId(), page);
     }
 
     /**
@@ -390,7 +390,7 @@ class ProfileServiceTest {
 
         mockAuthenticatedUser();
         mockProfileRepository(testProfile);
-        when(profileRepository.findAllFollowingById(testProfile.getProfileId(), page)).thenReturn(emptyFollowers);
+        when(profileRepository.findAllFollowingById(testProfile.getId(), page)).thenReturn(emptyFollowers);
         when(httpRequest.getRequestURI()).thenReturn(uri);
 
         // act
@@ -399,7 +399,7 @@ class ProfileServiceTest {
         // assert
         assertTrue(actual.items().isEmpty());
         assertEquals(expected, actual);
-        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getProfileId(), page);
+        verify(profileRepository, times(1)).findAllFollowingById(testProfile.getId(), page);
     }
 
     /**

--- a/src/test/java/com/example/echo_api/unit/service/RelationshipServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/RelationshipServiceTest.java
@@ -55,7 +55,7 @@ class RelationshipServiceTest {
         target = new Profile(targetAcc);
 
         // set ids with reflection
-        Field idField = Profile.class.getDeclaredField("profileId");
+        Field idField = Profile.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(source, UUID.randomUUID());
         idField.set(target, UUID.randomUUID());


### PR DESCRIPTION
## Purpose
PR introduces a refactor to `Profile` variable name `profileId` changed to `id`

## Changelog
- Updated `Profile` variable name `profileId` to `id`
- Updated `getProfileId` method calls to `getId` where applicable
- Updated any unit testing instances of Java reflection being used to set immutable field `profileId` to match updated variable name 
