### PR TITLE
feat: profile avatar/banner support

### DIFF
--- a/src/main/java/com/example/echo_api/config/ApiConfig.java
+++ b/src/main/java/com/example/echo_api/config/ApiConfig.java
@@ -32,6 +32,9 @@ public final class ApiConfig {
     public static final class Profile {
         private static final String ROOT = BASE_URL + "/profile";
         public static final String ME = ROOT + "/me";
+        public static final String ME_INFO = ROOT + "/me/info";
+        public static final String ME_AVATAR = ROOT + "/me/avatar";
+        public static final String ME_BANNER = ROOT + "/me/banner";
         public static final String GET_BY_USERNAME = ROOT + "/{username}";
         public static final String GET_FOLLOWERS_BY_USERNAME = ROOT + "/{username}/followers";
         public static final String GET_FOLLOWING_BY_USERNAME = ROOT + "/{username}/following";

--- a/src/main/java/com/example/echo_api/config/ValidationMessageConfig.java
+++ b/src/main/java/com/example/echo_api/config/ValidationMessageConfig.java
@@ -26,5 +26,10 @@ public final class ValidationMessageConfig {
     public static final String CONFIRMATION_PASSWORD_MISMATCH = "Confirmation password does not match the new password.";
     public static final String NEW_PASSWORD_NOT_UNIQUE = "New password cannot be the same as the current password.";
 
+    /* PROFILE */
+    public static final String NAME_TOO_LONG = "Name must not exceed 50 characters.";
+    public static final String BIO_TOO_LONG = "Bio must not exceed 160 characters.";
+    public static final String LOCATION_TOO_LONG = "Location must not exceed 30 characters.";
+
 }
 // @formatter:on

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
@@ -11,6 +12,7 @@ import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
 import com.example.echo_api.persistence.dto.response.profile.ProfileDTO;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.util.pagination.OffsetLimitRequest;
+import com.example.echo_api.util.validator.ImageValidator;
 import com.example.echo_api.validation.pagination.annotations.Limit;
 import com.example.echo_api.validation.pagination.annotations.Offset;
 
@@ -41,6 +43,32 @@ public class ProfileController {
     @PutMapping(ApiConfig.Profile.ME)
     public ResponseEntity<Void> updateMeProfile(@RequestBody @Valid UpdateProfileDTO request) {
         profileService.updateMeProfile(request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping(ApiConfig.Profile.ME_AVATAR)
+    public ResponseEntity<Void> updateMeAvatar(@RequestBody MultipartFile file) {
+        ImageValidator.validate(file);
+        profileService.updateMeAvatar(file);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(ApiConfig.Profile.ME_AVATAR)
+    public ResponseEntity<Void> deleteMeAvatar() {
+        profileService.deleteMeAvatar();
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping(ApiConfig.Profile.ME_BANNER)
+    public ResponseEntity<Void> updateMeBanner(@RequestBody MultipartFile file) {
+        ImageValidator.validate(file);
+        profileService.updateMeBanner(file);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(ApiConfig.Profile.ME_BANNER)
+    public ResponseEntity<Void> deleteMeBanner() {
+        profileService.deleteMeBanner();
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -41,7 +41,7 @@ public class ProfileController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping(ApiConfig.Profile.ME)
+    @PutMapping(ApiConfig.Profile.ME_INFO)
     public ResponseEntity<Void> updateMeProfile(@RequestBody @Valid UpdateProfileDTO request) {
         profileService.updateMeProfile(request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,8 +47,8 @@ public class ProfileController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping(ApiConfig.Profile.ME_AVATAR)
-    public ResponseEntity<Void> updateMeAvatar(@RequestBody MultipartFile file) {
+    @PostMapping(ApiConfig.Profile.ME_AVATAR)
+    public ResponseEntity<Void> updateMeAvatar(@RequestPart("file") MultipartFile file) {
         ImageValidator.validate(file);
         profileService.updateMeAvatar(file);
         return ResponseEntity.noContent().build();
@@ -59,8 +60,8 @@ public class ProfileController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping(ApiConfig.Profile.ME_BANNER)
-    public ResponseEntity<Void> updateMeBanner(@RequestBody MultipartFile file) {
+    @PostMapping(ApiConfig.Profile.ME_BANNER)
+    public ResponseEntity<Void> updateMeBanner(@RequestPart("file") MultipartFile file) {
         ImageValidator.validate(file);
         profileService.updateMeBanner(file);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/echo_api/persistence/dto/request/profile/UpdateProfileDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/request/profile/UpdateProfileDTO.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.persistence.dto.request.profile;
 
+import com.example.echo_api.config.ValidationMessageConfig;
+
 import jakarta.validation.constraints.Size;
 
 /**
@@ -15,13 +17,13 @@ import jakarta.validation.constraints.Size;
 // @formatter:off
 public record UpdateProfileDTO(
 
-    @Size(max = 50, message = "Name must not exceed 50 characters.")
+    @Size(max = 50, message = ValidationMessageConfig.NAME_TOO_LONG)
     String name,
 
-    @Size(max = 160, message = "Bio must not exceed 160 characters.")
+    @Size(max = 160, message = ValidationMessageConfig.BIO_TOO_LONG)
     String bio,
 
-    @Size(max = 30, message = "Location must not exceed 30 characters.")
+    @Size(max = 30, message = ValidationMessageConfig.LOCATION_TOO_LONG)
     String location
     
 ) {}

--- a/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
+++ b/src/main/java/com/example/echo_api/persistence/mapper/ProfileMapper.java
@@ -19,8 +19,8 @@ public class ProfileMapper {
             profile.getName(),
             profile.getBio(),
             profile.getLocation(),
-            profile.getAvatarUrl(),
-            profile.getBannerUrl(),
+            profile.getAvatar() != null ? profile.getAvatar().getTransformedUrl() : null,
+            profile.getBanner() != null ? profile.getBanner().getTransformedUrl() : null,
             profile.getCreatedAt(),
             metrics,
             relationship);

--- a/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
+++ b/src/main/java/com/example/echo_api/persistence/model/profile/Profile.java
@@ -7,11 +7,14 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.image.Image;
 import com.example.echo_api.validation.account.annotations.Username;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,11 +42,13 @@ public class Profile {
 
     private String location;
 
-    @Column(name = "avatar_url")
-    private String avatarUrl;
+    @OneToOne
+    @JoinColumn(name = "avatar_id")
+    private Image avatar;
 
-    @Column(name = "banner_url")
-    private String bannerUrl;
+    @OneToOne
+    @JoinColumn(name = "banner_id")
+    private Image banner;
 
     @CreationTimestamp
     @Column(name = "created_at")
@@ -74,12 +79,12 @@ public class Profile {
         this.location = location;
     }
 
-    public void setAvatarUrl(String avatarUrl) {
-        this.avatarUrl = avatarUrl;
+    public void setAvatar(Image avatar) {
+        this.avatar = avatar;
     }
 
-    public void setBannerUrl(String bannerUrl) {
-        this.bannerUrl = bannerUrl;
+    public void setBanner(Image banner) {
+        this.banner = banner;
     }
 
 }

--- a/src/main/java/com/example/echo_api/service/profile/ProfileService.java
+++ b/src/main/java/com/example/echo_api/service/profile/ProfileService.java
@@ -3,7 +3,10 @@ package com.example.echo_api.service.profile;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.example.echo_api.exception.custom.cloudinary.CloudinaryException;
+import com.example.echo_api.exception.custom.image.ImageException;
 import com.example.echo_api.exception.custom.username.UsernameNotFoundException;
 import com.example.echo_api.persistence.dto.request.profile.UpdateProfileDTO;
 import com.example.echo_api.persistence.dto.response.pagination.PageDTO;
@@ -40,6 +43,50 @@ public interface ProfileService {
      *                profile information.
      */
     public void updateMeProfile(UpdateProfileDTO request);
+
+    /**
+     * Updates the profile avatar image of the authenticated user.
+     * 
+     * @param image The {@link MultipartFile} resembling the uploaded image.
+     * @throws ImageException      If there is an existing avatar and its
+     *                             {@link Image} entity could not be found when
+     *                             deleting.
+     * @throws CloudinaryException If there was an error when interacting with the
+     *                             Cloudinary SDK.
+     */
+    public void updateMeAvatar(MultipartFile image) throws ImageException, CloudinaryException;
+
+    /**
+     * Removes the profile avatar image of the authenticated user.
+     * 
+     * @throws ImageException      If the existing avatar's {@link Image} entity
+     *                             could not be found when deleting.
+     * @throws CloudinaryException If there was an error when interacting with the
+     *                             Cloudinary SDK.
+     */
+    public void deleteMeAvatar() throws ImageException, CloudinaryException;
+
+    /**
+     * Updates the profile banner image of the authenticated user.
+     * 
+     * @param image The {@link MultipartFile} resembling the uploaded image.
+     * @throws ImageException      If there is an existing banner and its
+     *                             {@link Image} entity could not be found when
+     *                             deleting.
+     * @throws CloudinaryException If there was an error when interacting with the
+     *                             Cloudinary SDK.
+     */
+    public void updateMeBanner(MultipartFile image) throws ImageException, CloudinaryException;
+
+    /**
+     * Removes the profile avatar image of the authenticated user.
+     * 
+     * @throws ImageException      If the existing banner's {@link Image} entity
+     *                             could not be found when deleting.
+     * @throws CloudinaryException If there was an error when interacting with the
+     *                             Cloudinary SDK.
+     */
+    public void deleteMeBanner() throws ImageException, CloudinaryException;
 
     /**
      * Fetches a {@link List} of {@link Profile} for the followers list of the

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -33,12 +33,14 @@ CREATE TABLE
         name          VARCHAR(50),
         bio           VARCHAR(160),
         location      VARCHAR(30),
-        avatar_url    VARCHAR(255),
-        banner_url    VARCHAR(255),
+        avatar_id     UUID,
+        banner_id     UUID,
         created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         CONSTRAINT fk_profile_id FOREIGN KEY (profile_id) REFERENCES "account"(id) ON DELETE CASCADE,
-        CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES "account"(username) ON UPDATE CASCADE
+        CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES "account"(username) ON UPDATE CASCADE,
+        CONSTRAINT fk_avatar_id FOREIGN KEY (avatar_id) REFERENCES "image"(image_id) ON DELETE SET NULL,
+        CONSTRAINT fk_banner_id FOREIGN KEY (banner_id) REFERENCES "image"(image_id) ON DELETE SET NULL
     );
 
 CREATE UNIQUE INDEX 

--- a/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
+++ b/src/test/java/com/example/echo_api/integration/controller/ProfileControllerIT.java
@@ -62,9 +62,9 @@ class ProfileControllerIT extends IntegrationTest {
     }
 
     @Test
-    void ProfileController_UpdateMe_Return204NoContent() {
-        // api: PUT /api/v1/profile/me ==> 204 : No Content
-        String path = ApiConfig.Profile.ME;
+    void ProfileController_UpdateMeProfile_Return204NoContent() {
+        // api: PUT /api/v1/profile/me/info ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_INFO;
 
         UpdateProfileDTO body = new UpdateProfileDTO(
             "name",

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.config.ErrorMessageConfig;
+import com.example.echo_api.config.ValidationMessageConfig;
 import com.example.echo_api.controller.profile.ProfileController;
 import com.example.echo_api.exception.custom.relationship.AlreadyBlockingException;
 import com.example.echo_api.exception.custom.relationship.AlreadyFollowingException;
@@ -167,7 +168,7 @@ class ProfileControllerTest {
         ErrorDTO expected = new ErrorDTO(
             HttpStatus.BAD_REQUEST,
             ErrorMessageConfig.INVALID_REQUEST,
-            "Name must not exceed 50 characters.",
+            ValidationMessageConfig.NAME_TOO_LONG,
             path);
 
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
@@ -203,7 +204,7 @@ class ProfileControllerTest {
         ErrorDTO expected = new ErrorDTO(
             HttpStatus.BAD_REQUEST,
             ErrorMessageConfig.INVALID_REQUEST,
-            "Bio must not exceed 160 characters.",
+            ValidationMessageConfig.BIO_TOO_LONG,
             path);
 
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
@@ -239,7 +240,7 @@ class ProfileControllerTest {
         ErrorDTO expected = new ErrorDTO(
             HttpStatus.BAD_REQUEST,
             ErrorMessageConfig.INVALID_REQUEST,
-            "Location must not exceed 30 characters.",
+            ValidationMessageConfig.LOCATION_TOO_LONG,
             path);
 
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
@@ -8,9 +8,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -20,6 +23,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,6 +31,9 @@ import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.config.ErrorMessageConfig;
 import com.example.echo_api.config.ValidationMessageConfig;
 import com.example.echo_api.controller.profile.ProfileController;
+import com.example.echo_api.exception.custom.cloudinary.CloudinaryDeleteOperationException;
+import com.example.echo_api.exception.custom.cloudinary.CloudinaryUploadOperationException;
+import com.example.echo_api.exception.custom.image.ImageNotFoundException;
 import com.example.echo_api.exception.custom.relationship.AlreadyBlockingException;
 import com.example.echo_api.exception.custom.relationship.AlreadyFollowingException;
 import com.example.echo_api.exception.custom.relationship.BlockedException;
@@ -64,6 +71,27 @@ class ProfileControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    private static MockMultipartFile validImage;
+    private static MockMultipartFile invalidImageFileSize;
+    private static MockMultipartFile invalidImageFormat;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        validImage = readFileFromResources("data/valid_image.jpg", "image/jpeg");
+        invalidImageFileSize = readFileFromResources("data/invalid_image_file_size.jpg", "image/jpeg");
+        invalidImageFormat = readFileFromResources("data/invalid_image_format.pdf", "application/pdf");
+    }
+
+    private static MockMultipartFile readFileFromResources(String fileName, String fileType) throws IOException {
+        InputStream inputStream = ProfileControllerTest.class.getClassLoader().getResourceAsStream(fileName);
+
+        return new MockMultipartFile(
+            "file",
+            fileName,
+            fileType,
+            inputStream);
+    }
 
     @Test
     void ProfileController_GetMe_ReturnProfileDTO() throws Exception {
@@ -247,6 +275,430 @@ class ProfileControllerTest {
 
         assertEquals(expected, actual);
         verify(profileService, never()).updateMeProfile(request);
+    }
+
+    // update avatar
+
+    @Test
+    void ProfileController_UpdateMeAvatar_Return204NoContent() throws Exception {
+        // api: POST /api/v1/profile/me/avatar ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        MockMultipartFile file = validImage;
+
+        doNothing().when(profileService).updateMeAvatar(file);
+
+        mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        verify(profileService, times(1)).updateMeAvatar(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeAvatar_Throw400ImageFormat() throws Exception {
+        // api: POST /api/v1/profile/me/avatar ==> 400 : ImageFormat
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        MockMultipartFile file = invalidImageFormat;
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.INVALID_REQUEST,
+            ValidationMessageConfig.IMAGE_FORMAT_UNSUPPORTED,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, never()).updateMeAvatar(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeAvatar_Throw400ImageSize() throws Exception {
+        // api: POST /api/v1/profile/me/avatar ==> 400 : ImageSize
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        MockMultipartFile file = invalidImageFileSize;
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.INVALID_REQUEST,
+            ValidationMessageConfig.IMAGE_SIZE_TOO_LARGE,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, never()).updateMeAvatar(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeAvatar_Throw500CloudinaryUpload() throws Exception {
+        // api: POST /api/v1/profile/me/avatar ==> 500 : CloudinaryUploadOperation
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        MockMultipartFile file = validImage;
+
+        doThrow(new CloudinaryUploadOperationException("Placeholder"))
+            .when(profileService).updateMeAvatar(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).updateMeAvatar(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeAvatar_Throw500CloudinaryDelete() throws Exception {
+        // api: POST /api/v1/profile/me/avatar ==> 500 : CloudinaryDeleteOperation
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        MockMultipartFile file = validImage;
+
+        doThrow(new CloudinaryDeleteOperationException("Placeholder"))
+            .when(profileService).updateMeAvatar(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).updateMeAvatar(file);
+    }
+
+    // delete avatar
+
+    @Test
+    void ProfileController_DeleteMeAvatar_Return204NoContent() throws Exception {
+        // api: DELETE /api/v1/profile/me/avatar ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        doNothing().when(profileService).deleteMeAvatar();
+
+        mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        verify(profileService, times(1)).deleteMeAvatar();
+    }
+
+    @Test
+    void ProfileController_DeleteMeAvatar_Throw500CloudinaryDelete() throws Exception {
+        // api: DELETE /api/v1/profile/me/avatar ==> 500 : CloudinaryDeleteOperation
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        doThrow(new CloudinaryDeleteOperationException("Placeholder"))
+            .when(profileService).deleteMeAvatar();
+
+        String response = mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).deleteMeAvatar();
+    }
+
+    @Test
+    void ProfileController_DeleteMeAvatar_Throw400ImageNotFound() throws Exception {
+        // api: DELETE /api/v1/profile/me/avatar ==> 400 : ImageNotFound
+        String path = ApiConfig.Profile.ME_AVATAR;
+
+        doThrow(new ImageNotFoundException()).when(profileService).deleteMeAvatar();
+
+        String response = mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.IMAGE_NOT_FOUND,
+            null,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).deleteMeAvatar();
+    }
+
+    // update banner
+
+    @Test
+    void ProfileController_UpdateMeBanner_Return204NoContent() throws Exception {
+        // api: POST /api/v1/profile/me/banner ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        MockMultipartFile file = validImage;
+
+        doNothing().when(profileService).updateMeBanner(file);
+
+        mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        verify(profileService, times(1)).updateMeBanner(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeBanner_Throw400ImageFormat() throws Exception {
+        // api: POST /api/v1/profile/me/banner ==> 400 : ImageFormat
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        MockMultipartFile file = invalidImageFormat;
+
+        doNothing().when(profileService).updateMeBanner(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.INVALID_REQUEST,
+            ValidationMessageConfig.IMAGE_FORMAT_UNSUPPORTED,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, never()).updateMeBanner(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeBanner_Throw400ImageSize() throws Exception {
+        // api: POST /api/v1/profile/me/banner ==> 400 : ImageSize
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        MockMultipartFile file = invalidImageFileSize;
+
+        doNothing().when(profileService).updateMeBanner(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.INVALID_REQUEST,
+            ValidationMessageConfig.IMAGE_SIZE_TOO_LARGE,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, never()).updateMeBanner(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeBanner_Throw500CloudinaryUpload() throws Exception {
+        // api: POST /api/v1/profile/me/banner ==> 500 : CloudinaryUploadOperation
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        MockMultipartFile file = validImage;
+
+        doThrow(new CloudinaryUploadOperationException("Placeholder"))
+            .when(profileService).updateMeBanner(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).updateMeBanner(file);
+    }
+
+    @Test
+    void ProfileController_UpdateMeBanner_Throw500CloudinaryDelete() throws Exception {
+        // api: POST /api/v1/profile/me/banner ==> 500 : CloudinaryDeleteOperation
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        MockMultipartFile file = validImage;
+
+        doThrow(new CloudinaryDeleteOperationException("Placeholder"))
+            .when(profileService).updateMeBanner(file);
+
+        String response = mockMvc
+            .perform(multipart(path)
+                .file(file))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).updateMeBanner(file);
+    }
+
+    // delete banner
+
+    @Test
+    void ProfileController_DeleteMeBanner_Return204NoContent() throws Exception {
+        // api: DELETE /api/v1/profile/me/banner ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        doNothing().when(profileService).deleteMeBanner();
+
+        mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        verify(profileService, times(1)).deleteMeBanner();
+    }
+
+    @Test
+    void ProfileController_DeleteMeBanner_Throw404ImageNotFound() throws Exception {
+        // api: DELETE /api/v1/profile/me/banner ==> 404 : ImageNotFound
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        doThrow(new ImageNotFoundException()).when(profileService).deleteMeBanner();
+
+        String response = mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.IMAGE_NOT_FOUND,
+            null,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).deleteMeBanner();
+    }
+
+    @Test
+    void ProfileController_DeleteMeBanner_Throw500CloudinaryDelete() throws Exception {
+        // api: DELETE /api/v1/profile/me/banner ==> 500 : CloudinaryDeleteOperation
+        String path = ApiConfig.Profile.ME_BANNER;
+
+        doThrow(new CloudinaryDeleteOperationException("Placeholder"))
+            .when(profileService).deleteMeBanner();
+
+        String response = mockMvc
+            .perform(delete(path))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ErrorMessageConfig.CLOUDINARY_SDK_ERROR,
+            "Placeholder",
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileService, times(1)).deleteMeBanner();
     }
 
     @Test

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileControllerTest.java
@@ -146,9 +146,9 @@ class ProfileControllerTest {
     }
 
     @Test
-    void ProfileController_UpdateMe_Return204NoContent() throws Exception {
-        // api: PUT /api/v1/profile/me ==> 204 : No Content
-        String path = ApiConfig.Profile.ME;
+    void ProfileController_UpdateMeProfile_Return204NoContent() throws Exception {
+        // api: PUT /api/v1/profile/me/info ==> 204 : No Content
+        String path = ApiConfig.Profile.ME_INFO;
 
         UpdateProfileDTO request = new UpdateProfileDTO(
             "name",
@@ -170,9 +170,9 @@ class ProfileControllerTest {
     }
 
     @Test
-    void ProfileController_UpdateMe_Throw400InvalidRequest_NameExceeds50Characters() throws Exception {
-        // api: PUT /api/v1/profile/me ==> 400 : Invalid Request
-        String path = ApiConfig.Profile.ME;
+    void ProfileController_UpdateMeProfile_Throw400InvalidRequest_NameExceeds50Characters() throws Exception {
+        // api: PUT /api/v1/profile/me/info ==> 400 : Invalid Request
+        String path = ApiConfig.Profile.ME_INFO;
 
         UpdateProfileDTO request = new UpdateProfileDTO(
             "ThisNameIsTooLongBy......................1Character",
@@ -206,9 +206,9 @@ class ProfileControllerTest {
     }
 
     @Test
-    void ProfileController_UpdateMe_Throw400InvalidRequest_BioExceeds160Characters() throws Exception {
-        // api: PUT /api/v1/profile/me ==> 400 : Invalid Request
-        String path = ApiConfig.Profile.ME;
+    void ProfileController_UpdateMeProfile_Throw400InvalidRequest_BioExceeds160Characters() throws Exception {
+        // api: PUT /api/v1/profile/me/info ==> 400 : Invalid Request
+        String path = ApiConfig.Profile.ME_INFO;
 
         UpdateProfileDTO request = new UpdateProfileDTO(
             "name",
@@ -242,9 +242,9 @@ class ProfileControllerTest {
     }
 
     @Test
-    void ProfileController_UpdateMe_Throw400InvalidRequest_LocationExceeds30Characters() throws Exception {
-        // api: PUT /api/v1/profile/me ==> 400 : Invalid Request
-        String path = ApiConfig.Profile.ME;
+    void ProfileController_UpdateMeProfile_Throw400InvalidRequest_LocationExceeds30Characters() throws Exception {
+        // api: PUT /api/v1/profile/me/info ==> 400 : Invalid Request
+        String path = ApiConfig.Profile.ME_INFO;
 
         UpdateProfileDTO request = new UpdateProfileDTO(
             "name",
@@ -276,8 +276,6 @@ class ProfileControllerTest {
         assertEquals(expected, actual);
         verify(profileService, never()).updateMeProfile(request);
     }
-
-    // update avatar
 
     @Test
     void ProfileController_UpdateMeAvatar_Return204NoContent() throws Exception {
@@ -415,8 +413,6 @@ class ProfileControllerTest {
         verify(profileService, times(1)).updateMeAvatar(file);
     }
 
-    // delete avatar
-
     @Test
     void ProfileController_DeleteMeAvatar_Return204NoContent() throws Exception {
         // api: DELETE /api/v1/profile/me/avatar ==> 204 : No Content
@@ -486,8 +482,6 @@ class ProfileControllerTest {
         assertEquals(expected, actual);
         verify(profileService, times(1)).deleteMeAvatar();
     }
-
-    // update banner
 
     @Test
     void ProfileController_UpdateMeBanner_Return204NoContent() throws Exception {
@@ -628,8 +622,6 @@ class ProfileControllerTest {
         assertEquals(expected, actual);
         verify(profileService, times(1)).updateMeBanner(file);
     }
-
-    // delete banner
 
     @Test
     void ProfileController_DeleteMeBanner_Return204NoContent() throws Exception {

--- a/src/test/java/com/example/echo_api/unit/mapper/ProfileMapperTest.java
+++ b/src/test/java/com/example/echo_api/unit/mapper/ProfileMapperTest.java
@@ -28,8 +28,10 @@ class ProfileMapperTest {
         assertEquals(profile.getName(), response.name());
         assertEquals(profile.getBio(), response.bio());
         assertEquals(profile.getLocation(), response.location());
-        assertEquals(profile.getAvatarUrl(), response.avatarUrl());
-        assertEquals(profile.getBannerUrl(), response.bannerUrl());
+        assertEquals(profile.getAvatar() != null ? profile.getAvatar().getTransformedUrl() : null,
+            response.avatarUrl());
+        assertEquals(profile.getBanner() != null ? profile.getBanner().getTransformedUrl() : null,
+            response.bannerUrl());
         assertEquals(metrics.followingCount(), response.metrics().followingCount());
         assertEquals(metrics.followerCount(), response.metrics().followerCount());
         assertEquals(metrics.postCount(), response.metrics().postCount());

--- a/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileServiceTest.java
@@ -17,6 +17,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import com.example.echo_api.config.ErrorMessageConfig;
+import com.example.echo_api.exception.custom.cloudinary.CloudinaryDeleteOperationException;
+import com.example.echo_api.exception.custom.cloudinary.CloudinaryUploadOperationException;
+import com.example.echo_api.exception.custom.image.ImageNotFoundException;
 import com.example.echo_api.exception.custom.relationship.AlreadyBlockingException;
 import com.example.echo_api.exception.custom.relationship.AlreadyFollowingException;
 import com.example.echo_api.exception.custom.relationship.BlockedException;
@@ -32,8 +35,11 @@ import com.example.echo_api.persistence.dto.response.profile.RelationshipDTO;
 import com.example.echo_api.persistence.mapper.PageMapper;
 import com.example.echo_api.persistence.mapper.ProfileMapper;
 import com.example.echo_api.persistence.model.account.Account;
+import com.example.echo_api.persistence.model.image.Image;
+import com.example.echo_api.persistence.model.image.ImageType;
 import com.example.echo_api.persistence.model.profile.Profile;
 import com.example.echo_api.persistence.repository.ProfileRepository;
+import com.example.echo_api.service.file.FileService;
 import com.example.echo_api.service.metrics.profile.ProfileMetricsService;
 import com.example.echo_api.service.profile.ProfileService;
 import com.example.echo_api.service.profile.ProfileServiceImpl;
@@ -57,6 +63,9 @@ class ProfileServiceTest {
 
     @Mock
     private RelationshipService relationshipService;
+
+    @Mock
+    private FileService fileService;
 
     @Mock
     private ProfileRepository profileRepository;
@@ -237,6 +246,186 @@ class ProfileServiceTest {
         // act & assert
         assertThrows(UsernameNotFoundException.class, () -> profileService.updateMeProfile(request));
         verify(profileRepository, times(1)).findByUsername(authenticatedAccount.getUsername());
+    }
+
+    // update avatar
+
+    @Test
+    void ProfileService_UpdateMeAvatar_ReturnVoid() {
+        // arrange
+        Image expected = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.AVATAR)).thenReturn(expected);
+
+        // act & assert
+        assertDoesNotThrow(() -> profileService.updateMeAvatar(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeAvatar_ThrowCloudinaryUploadOperation() {
+        // arrange
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.AVATAR)).thenThrow(new CloudinaryUploadOperationException(""));
+
+        // act & assert
+        assertThrows(CloudinaryUploadOperationException.class, () -> profileService.updateMeAvatar(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeAvatar_ThrowImageNotFound() {
+        // arrange
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.AVATAR)).thenThrow(new ImageNotFoundException());
+
+        // act & assert
+        assertThrows(ImageNotFoundException.class, () -> profileService.updateMeAvatar(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeAvatar_ThrowCloudinaryDeleteOperation() {
+        // arrange
+        Image avatar = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setAvatar(avatar);
+        doThrow(new CloudinaryDeleteOperationException("")).when(fileService)
+            .deleteImage(authenticatedProfile.getAvatar().getId());
+
+        // act & assert
+        assertThrows(CloudinaryDeleteOperationException.class, () -> profileService.updateMeAvatar(null));
+    }
+
+    // delete avatar
+
+    @Test
+    void ProfileService_DeleteMeAvatar_ReturnVoid() {
+        // arrange
+        Image avatar = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setAvatar(avatar);
+        doNothing().when(fileService).deleteImage(authenticatedProfile.getAvatar().getId());
+
+        // act & assert
+        assertDoesNotThrow(() -> profileService.deleteMeAvatar());
+    }
+
+    @Test
+    void ProfileService_DeleteMeAvatar_ThrowImageNotFound() {
+        // arrange
+        Image avatar = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setAvatar(avatar);
+        doThrow(new ImageNotFoundException()).when(fileService).deleteImage(authenticatedProfile.getAvatar().getId());
+
+        // act & assert
+        assertThrows(ImageNotFoundException.class, () -> profileService.deleteMeAvatar());
+    }
+
+    @Test
+    void ProfileService_DeleteMeAvatar_ThrowCloudinaryDeleteOperation() {
+        // arrange
+        Image avatar = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setAvatar(avatar);
+        doThrow(new CloudinaryDeleteOperationException("")).when(fileService)
+            .deleteImage(authenticatedProfile.getAvatar().getId());
+
+        // act & assert
+        assertThrows(CloudinaryDeleteOperationException.class, () -> profileService.deleteMeAvatar());
+    }
+
+    // update banner
+
+    @Test
+    void ProfileService_UpdateMeBanner_ReturnVoid() {
+        // arrange
+        Image expected = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.BANNER)).thenReturn(expected);
+
+        // act & assert
+        assertDoesNotThrow(() -> profileService.updateMeBanner(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeBanner_ThrowCloudinaryUploadOperation() {
+        // arrange
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.BANNER)).thenThrow(new CloudinaryUploadOperationException(""));
+
+        // act & assert
+        assertThrows(CloudinaryUploadOperationException.class, () -> profileService.updateMeBanner(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeBanner_ThrowImageNotFound() {
+        // arrange
+        mockAuthenticatedUser();
+        when(fileService.createImage(null, ImageType.BANNER)).thenThrow(new ImageNotFoundException());
+
+        // act & assert
+        assertThrows(ImageNotFoundException.class, () -> profileService.updateMeBanner(null));
+    }
+
+    @Test
+    void ProfileService_UpdateMeBanner_ThrowCloudinaryDeleteOperation() {
+        // arrange
+        Image banner = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setBanner(banner);
+        doThrow(new CloudinaryDeleteOperationException("")).when(fileService)
+            .deleteImage(authenticatedProfile.getBanner().getId());
+
+        // act & assert
+        assertThrows(CloudinaryDeleteOperationException.class, () -> profileService.updateMeBanner(null));
+    }
+
+    // delete banner
+
+    @Test
+    void ProfileService_DeleteMeBanner_ReturnVoid() {
+        // arrange
+        Image banner = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setBanner(banner);
+        doNothing().when(fileService).deleteImage(authenticatedProfile.getBanner().getId());
+
+        // act & assert
+        assertDoesNotThrow(() -> profileService.deleteMeBanner());
+    }
+
+    @Test
+    void ProfileService_DeleteMeBanner_ThrowImageNotFound() {
+        // arrange
+        Image banner = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setBanner(banner);
+        doThrow(new ImageNotFoundException()).when(fileService).deleteImage(authenticatedProfile.getBanner().getId());
+
+        // act & assert
+        assertThrows(ImageNotFoundException.class, () -> profileService.deleteMeBanner());
+    }
+
+    @Test
+    void ProfileService_DeleteMeBanner_ThrowCloudinaryDeleteOperation() {
+        // arrange
+        Image banner = new Image(null, null, null, 0, 0, null, null);
+
+        mockAuthenticatedUser();
+        authenticatedProfile.setBanner(banner);
+        doThrow(new CloudinaryDeleteOperationException("")).when(fileService)
+            .deleteImage(authenticatedProfile.getBanner().getId());
+
+        // act & assert
+        assertThrows(CloudinaryDeleteOperationException.class, () -> profileService.deleteMeBanner());
     }
 
     /**


### PR DESCRIPTION
## Purpose
PR introduces image support for profile avatars and banners.

### Relevant endpoints

`POST /api/v1/profile/me/avatar`
`DELETE /api/v1/profile/me/avatar`

`POST /api/v1/profile/me/banner`
`DELETE /api/v1/profile/me/banner`

Note that the images must be supplied in JPEG or PNG format, at a maximum of 2MB file size.

## Changelog
### Config
- Added separate profile information/avatar/banner endpoints to `ApiConfig`
- Added additional validation messages for updating profile information to `ValidationMessageConfig`

### DB Schema
- Refactored `profile` table to store `avatar_id` and `banner_id` as a foreign key from `image.image_id`

### Persistence
- Refactored `Profile` entity to handle a `@OneToOne` join to `Image` entity using the stored `avatar_id` and `banner_id`
- Refctored `ProfileMapper` to correctly obtain the avatar and banner URLs

### Controllers
- Added `ProfileController` methods for handling `POST` and `DELETE` requests to `/me/avatar` and `me/banner` endpoints

### Services
- Added `ProfileService` methods `updateMeAvatar` `deleteMeAvatar` `updateMeBanner` `deleteMeBanner`

### Testing
- Added additional `ProfileController` unit tests
- Added additional `ProfileService` unit tests