### PR TITLE
refactor: post entity pk

### DIFF
--- a/src/main/java/com/example/echo_api/persistence/model/post/entity/PostEntity.java
+++ b/src/main/java/com/example/echo_api/persistence/model/post/entity/PostEntity.java
@@ -7,23 +7,23 @@ import java.util.UUID;
 import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @MappedSuperclass
+@IdClass(PostEntityPK.class)
 public abstract class PostEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
-
     @Column(name = "post_id", nullable = false)
     private UUID postId;
 
+    @Id
     @Column(name = "start_index", nullable = false)
     private int start;
 

--- a/src/main/java/com/example/echo_api/persistence/model/post/entity/PostEntityPK.java
+++ b/src/main/java/com/example/echo_api/persistence/model/post/entity/PostEntityPK.java
@@ -1,0 +1,18 @@
+package com.example.echo_api.persistence.model.post.entity;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ID class representing a composite primary key for {@link PostEntity} entity.
+ */
+@Getter
+@NoArgsConstructor
+public class PostEntityPK {
+
+    private UUID postId;
+
+    private int start;
+
+}

--- a/src/main/java/com/example/echo_api/persistence/model/post/entity/PostHashtag.java
+++ b/src/main/java/com/example/echo_api/persistence/model/post/entity/PostHashtag.java
@@ -4,8 +4,10 @@ import java.util.UUID;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
 @Table(name = "post_hashtag")
 public class PostHashtag extends PostEntity {
 

--- a/src/main/java/com/example/echo_api/persistence/model/post/entity/PostMention.java
+++ b/src/main/java/com/example/echo_api/persistence/model/post/entity/PostMention.java
@@ -4,8 +4,10 @@ import java.util.UUID;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
 @Table(name = "post_mention")
 public class PostMention extends PostEntity {
 

--- a/src/main/resources/sql/schema/07_schema-post-entities.sql
+++ b/src/main/resources/sql/schema/07_schema-post-entities.sql
@@ -1,11 +1,11 @@
 CREATE TABLE
     IF NOT EXISTS "post_hashtag" (
-        id             UUID PRIMARY KEY,
         post_id        UUID NOT NULL,
         start_index    INTEGER NOT NULL,
         end_index      INTEGER NOT NULL,
         text           TEXT NOT NULL,
         created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (post_id, start_index),
         CONSTRAINT fk_post_id FOREIGN KEY (post_id) REFERENCES "post"(id) ON DELETE CASCADE
     );
 
@@ -19,12 +19,12 @@ CREATE INDEX
 
 CREATE TABLE
     IF NOT EXISTS "post_mention" (
-        id             UUID PRIMARY KEY,
         post_id        UUID NOT NULL,
         start_index    INTEGER NOT NULL,
         end_index      INTEGER NOT NULL,
         text           TEXT NOT NULL,
         created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (post_id, start_index),
         CONSTRAINT fk_post_id FOREIGN KEY (post_id) REFERENCES "post"(id) ON DELETE CASCADE
     );
 

--- a/src/test/resources/sql/schema/07_schema-post-entities.sql
+++ b/src/test/resources/sql/schema/07_schema-post-entities.sql
@@ -1,11 +1,11 @@
 CREATE TABLE
     IF NOT EXISTS "post_hashtag" (
-        id             UUID PRIMARY KEY,
         post_id        UUID NOT NULL,
         start_index    INTEGER NOT NULL,
         end_index      INTEGER NOT NULL,
         text           TEXT NOT NULL,
         created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (post_id, start_index),
         CONSTRAINT fk_post_id FOREIGN KEY (post_id) REFERENCES "post"(id) ON DELETE CASCADE
     );
 
@@ -19,12 +19,12 @@ CREATE INDEX
 
 CREATE TABLE
     IF NOT EXISTS "post_mention" (
-        id             UUID PRIMARY KEY,
         post_id        UUID NOT NULL,
         start_index    INTEGER NOT NULL,
         end_index      INTEGER NOT NULL,
         text           TEXT NOT NULL,
         created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (post_id, start_index),
         CONSTRAINT fk_post_id FOREIGN KEY (post_id) REFERENCES "post"(id) ON DELETE CASCADE
     );
 


### PR DESCRIPTION
## Purpose
PR introduces a small refactor to post entity-related tables by migrating from a dedicated `id` primary key to a composite primary key consisting of `post_id` and `start_index` 

## Changelog
### DB Schema
- Delete `id` column from `post_hashtag` and `post_mention` tables
- Add composite PK consisting of `post_id` and `start_index` to `post_hashtag` and `post_mention` tables

### Persistence
- Add `PostEntityPK` class to `model.post.entity` package
- Refactor abstract `PostEntity` entity to use composite PK class `PostEntityPK`