### PR TITLE
fix: repository primary key references

### DIFF
--- a/src/main/java/com/example/echo_api/persistence/repository/PostHashtagRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/PostHashtagRepository.java
@@ -1,11 +1,10 @@
 package com.example.echo_api.persistence.repository;
 
-import java.util.UUID;
-
 import org.springframework.data.repository.ListCrudRepository;
 
 import com.example.echo_api.persistence.model.post.entity.PostEntity;
+import com.example.echo_api.persistence.model.post.entity.PostEntityPK;
 
-public interface PostHashtagRepository extends ListCrudRepository<PostEntity, UUID> {
+public interface PostHashtagRepository extends ListCrudRepository<PostEntity, PostEntityPK> {
 
 }

--- a/src/main/java/com/example/echo_api/persistence/repository/PostMentionRepository.java
+++ b/src/main/java/com/example/echo_api/persistence/repository/PostMentionRepository.java
@@ -1,11 +1,10 @@
 package com.example.echo_api.persistence.repository;
 
-import java.util.UUID;
-
 import org.springframework.data.repository.ListCrudRepository;
 
 import com.example.echo_api.persistence.model.post.entity.PostEntity;
+import com.example.echo_api.persistence.model.post.entity.PostEntityPK;
 
-public interface PostMentionRepository extends ListCrudRepository<PostEntity, UUID> {
+public interface PostMentionRepository extends ListCrudRepository<PostEntity, PostEntityPK> {
 
 }


### PR DESCRIPTION
## Purpose
PR introduces a fix to the primary key references within post entity-related repositories

... how did gradle complete a build and test with a clear type error?!?!

## Changelog
### Persistence
- Update `PostHashtagRepository` and `PostMentionRepository` primary key references from `UUID` to `PostEntityPK`