### PR TITLE
fix: pagination validation

### DIFF
--- a/src/main/java/com/example/echo_api/controller/account/AccountController.java
+++ b/src/main/java/com/example/echo_api/controller/account/AccountController.java
@@ -8,7 +8,7 @@ import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.account.UpdatePasswordDTO;
 import com.example.echo_api.persistence.dto.request.account.UpdateUsernameDTO;
 import com.example.echo_api.service.account.AccountService;
-import com.example.echo_api.validation.sequence.ValidationOrder;
+import com.example.echo_api.validation.sequence.ValidationSequence;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +17,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Validated(ValidationSequence.class)
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class AccountController {
 
     private final AccountService accountService;

--- a/src/main/java/com/example/echo_api/controller/auth/AuthController.java
+++ b/src/main/java/com/example/echo_api/controller/auth/AuthController.java
@@ -10,14 +10,14 @@ import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.auth.LoginDTO;
 import com.example.echo_api.persistence.dto.request.auth.SignupDTO;
 import com.example.echo_api.service.auth.AuthService;
-import com.example.echo_api.validation.sequence.ValidationOrder;
+import com.example.echo_api.validation.sequence.ValidationSequence;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Validated(ValidationSequence.class)
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/example/echo_api/controller/post/PostInteractionController.java
+++ b/src/main/java/com/example/echo_api/controller/post/PostInteractionController.java
@@ -3,7 +3,6 @@ package com.example.echo_api.controller.post;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,13 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.service.post.interaction.PostInteractionService;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class PostInteractionController {
 
     private final PostInteractionService postInteractionService;

--- a/src/main/java/com/example/echo_api/controller/post/PostManagementController.java
+++ b/src/main/java/com/example/echo_api/controller/post/PostManagementController.java
@@ -13,14 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.post.CreatePostDTO;
 import com.example.echo_api.service.post.management.PostManagementService;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class PostManagementController {
 
     private final PostManagementService postManagementService;

--- a/src/main/java/com/example/echo_api/controller/post/PostViewController.java
+++ b/src/main/java/com/example/echo_api/controller/post/PostViewController.java
@@ -14,16 +14,15 @@ import com.example.echo_api.service.post.view.post.PostViewService;
 import com.example.echo_api.util.pagination.OffsetLimitRequest;
 import com.example.echo_api.validation.pagination.annotations.Limit;
 import com.example.echo_api.validation.pagination.annotations.Offset;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class PostViewController {
 
     private final PostViewService postViewService;

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileInteractionController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileInteractionController.java
@@ -1,7 +1,6 @@
 package com.example.echo_api.controller.profile;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,13 +8,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.service.profile.interaction.ProfileInteractionService;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class ProfileInteractionController {
 
     private final ProfileInteractionService profileInteractionService;

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileManagementController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileManagementController.java
@@ -14,14 +14,13 @@ import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.persistence.dto.request.profile.UpdateInformationDTO;
 import com.example.echo_api.service.profile.management.ProfileManagementService;
 import com.example.echo_api.util.validator.ImageValidator;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class ProfileManagementController {
 
     private final ProfileManagementService profileManagementService;

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileViewController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileViewController.java
@@ -16,13 +16,12 @@ import com.example.echo_api.service.profile.view.ProfileViewService;
 import com.example.echo_api.util.pagination.OffsetLimitRequest;
 import com.example.echo_api.validation.pagination.annotations.Limit;
 import com.example.echo_api.validation.pagination.annotations.Offset;
-import com.example.echo_api.validation.sequence.ValidationOrder;
 
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@Validated(ValidationOrder.class)
 public class ProfileViewController {
 
     private final ProfileViewService profileViewService;

--- a/src/main/java/com/example/echo_api/persistence/dto/request/account/UpdatePasswordDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/request/account/UpdatePasswordDTO.java
@@ -3,8 +3,8 @@ package com.example.echo_api.persistence.dto.request.account;
 import com.example.echo_api.validation.account.annotations.ConfirmationPasswordMatch;
 import com.example.echo_api.validation.account.annotations.NewPasswordUnique;
 import com.example.echo_api.validation.account.annotations.Password;
-import com.example.echo_api.validation.sequence.AdvancedCheck;
-import com.example.echo_api.validation.sequence.BasicCheck;
+import com.example.echo_api.validation.sequence.Advanced;
+import com.example.echo_api.validation.sequence.Basic;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.NotNull;
@@ -20,20 +20,20 @@ import jakarta.validation.constraints.NotNull;
  *                             Required field. Must match {@code newPassword}.
  */
 // @formatter:off
-@NewPasswordUnique(groups = AdvancedCheck.class)
-@ConfirmationPasswordMatch(groups = AdvancedCheck.class)
+@NewPasswordUnique(groups = Advanced.class)
+@ConfirmationPasswordMatch(groups = Advanced.class)
 public record UpdatePasswordDTO(
 
-    @NotNull(message = "Current password is required.", groups = BasicCheck.class)
+    @NotNull(message = "Current password is required.", groups = Basic.class)
     @JsonProperty("current_password")
     String currentPassword,
 
-    @NotNull(message = "New password is required.", groups = BasicCheck.class)
-    @Password(groups = AdvancedCheck.class)
+    @NotNull(message = "New password is required.", groups = Basic.class)
+    @Password(groups = Advanced.class)
     @JsonProperty("new_password")
     String newPassword,
 
-    @NotNull(message = "Confirmation password is required.", groups = BasicCheck.class)
+    @NotNull(message = "Confirmation password is required.", groups = Basic.class)
     @JsonProperty("confirmation_password")
     String confirmationPassword
 

--- a/src/main/java/com/example/echo_api/persistence/dto/request/account/UpdateUsernameDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/request/account/UpdateUsernameDTO.java
@@ -1,8 +1,8 @@
 package com.example.echo_api.persistence.dto.request.account;
 
 import com.example.echo_api.validation.account.annotations.Username;
-import com.example.echo_api.validation.sequence.AdvancedCheck;
-import com.example.echo_api.validation.sequence.BasicCheck;
+import com.example.echo_api.validation.sequence.Advanced;
+import com.example.echo_api.validation.sequence.Basic;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -15,8 +15,8 @@ import jakarta.validation.constraints.NotNull;
 // @formatter:off
 public record UpdateUsernameDTO(
 
-    @NotNull(message = "Username is required.", groups = BasicCheck.class)
-    @Username(groups = AdvancedCheck.class)
+    @NotNull(message = "Username is required.", groups = Basic.class)
+    @Username(groups = Advanced.class)
     String username
 
 ) {}

--- a/src/main/java/com/example/echo_api/persistence/dto/request/auth/SignupDTO.java
+++ b/src/main/java/com/example/echo_api/persistence/dto/request/auth/SignupDTO.java
@@ -2,8 +2,8 @@ package com.example.echo_api.persistence.dto.request.auth;
 
 import com.example.echo_api.validation.account.annotations.Password;
 import com.example.echo_api.validation.account.annotations.Username;
-import com.example.echo_api.validation.sequence.AdvancedCheck;
-import com.example.echo_api.validation.sequence.BasicCheck;
+import com.example.echo_api.validation.sequence.Advanced;
+import com.example.echo_api.validation.sequence.Basic;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -18,12 +18,12 @@ import jakarta.validation.constraints.NotNull;
 // @formatter:off
 public record SignupDTO(
 
-    @NotNull(message = "Username is required.", groups = BasicCheck.class)
-    @Username(groups = AdvancedCheck.class)
+    @NotNull(message = "Username is required.", groups = Basic.class)
+    @Username(groups = Advanced.class)
     String username,
     
-    @NotNull(message = "Password is required.", groups = BasicCheck.class)
-    @Password(groups = AdvancedCheck.class)
+    @NotNull(message = "Password is required.", groups = Basic.class)
+    @Password(groups = Advanced.class)
     String password
     
 ) {}

--- a/src/main/java/com/example/echo_api/validation/pagination/annotations/Limit.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/annotations/Limit.java
@@ -33,8 +33,8 @@ import jakarta.validation.Payload;
  * {@code
  * GetMapping("/items")
  * public ResponseEntity<PageDTO<ItemDTO>> getItems(
- *     RequestParam @Limit int limit,
- *     RequestParam int offset
+ *     RequestParam int offset,
+ *     RequestParam @Limit int limit
  * ) {
  *     // Method implementation
  * }

--- a/src/main/java/com/example/echo_api/validation/pagination/annotations/Offset.java
+++ b/src/main/java/com/example/echo_api/validation/pagination/annotations/Offset.java
@@ -33,8 +33,8 @@ import jakarta.validation.Payload;
  * {@code
  * GetMapping("/items")
  * public ResponseEntity<PageDTO<ItemDTO>> getItems(
- *     RequestParam int limit,
- *     RequestParam @Offset int offset
+ *     RequestParam @Offset int offset,
+ *     RequestParam int limit
  * ) {
  *     // Method implementation
  * }

--- a/src/main/java/com/example/echo_api/validation/sequence/Advanced.java
+++ b/src/main/java/com/example/echo_api/validation/sequence/Advanced.java
@@ -1,4 +1,4 @@
 package com.example.echo_api.validation.sequence;
 
-public interface BasicCheck {
+public interface Advanced {
 }

--- a/src/main/java/com/example/echo_api/validation/sequence/Basic.java
+++ b/src/main/java/com/example/echo_api/validation/sequence/Basic.java
@@ -1,4 +1,4 @@
 package com.example.echo_api.validation.sequence;
 
-public interface AdvancedCheck {
+public interface Basic {
 }

--- a/src/main/java/com/example/echo_api/validation/sequence/ValidationOrder.java
+++ b/src/main/java/com/example/echo_api/validation/sequence/ValidationOrder.java
@@ -1,7 +1,0 @@
-package com.example.echo_api.validation.sequence;
-
-import jakarta.validation.GroupSequence;
-
-@GroupSequence({ BasicCheck.class, AdvancedCheck.class })
-public interface ValidationOrder {
-}

--- a/src/main/java/com/example/echo_api/validation/sequence/ValidationSequence.java
+++ b/src/main/java/com/example/echo_api/validation/sequence/ValidationSequence.java
@@ -1,0 +1,12 @@
+package com.example.echo_api.validation.sequence;
+
+import jakarta.validation.GroupSequence;
+
+/**
+ * A custom Validation sequence to ensure basic checks, such as
+ * {@code @NotNull}, {@code @NotBlank}, are validated before advanced checks
+ * such as {@code @Username}, {@code @Password}.
+ */
+@GroupSequence({ Basic.class, Advanced.class })
+public interface ValidationSequence {
+}

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileViewControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileViewControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.echo_api.config.ApiConfig;
 import com.example.echo_api.config.ErrorMessageConfig;
+import com.example.echo_api.config.ValidationMessageConfig;
 import com.example.echo_api.controller.profile.ProfileViewController;
 import com.example.echo_api.exception.custom.notfound.ResourceNotFoundException;
 import com.example.echo_api.persistence.dto.response.error.ErrorDTO;
@@ -95,6 +96,7 @@ class ProfileViewControllerTest {
             .getContentAsString();
 
         ProfileDTO actual = objectMapper.readValue(response, ProfileDTO.class);
+
         assertEquals(expected, actual);
         verify(profileViewService, times(1)).getSelf();
     }
@@ -145,6 +147,7 @@ class ProfileViewControllerTest {
             .getContentAsString();
 
         ProfileDTO actual = objectMapper.readValue(response, ProfileDTO.class);
+
         assertEquals(expected, actual);
         verify(profileViewService, times(1)).getByUsername(username);
     }
@@ -207,10 +210,10 @@ class ProfileViewControllerTest {
             new TypeReference<PageDTO<SimplifiedProfileDTO>>() {
             });
 
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
         assertEquals(1, actual.total());
         assertEquals(1, actual.items().size());
+        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
     }
 
     @Test
@@ -241,10 +244,70 @@ class ProfileViewControllerTest {
         PageDTO<ProfileDTO> actual = objectMapper.readValue(response, new TypeReference<PageDTO<ProfileDTO>>() {
         });
 
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
         assertEquals(0, actual.total());
         assertEquals(0, actual.items().size());
+        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
+    }
+
+    @Test
+    void ProfileViewController_GetFollowers_Throw400InvalidRequest_InvalidOffset() throws Exception {
+        // api: GET /api/v1/profile/{username}/followers ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
+        String username = "existing-user";
+        int offset = -1;
+        int limit = 1;
+
+        String response = mockMvc
+            .perform(get(path, username)
+                .param("offset", String.valueOf(offset))
+                .param("limit", String.valueOf(limit)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.BadRequest.INVALID_REQUEST,
+            ValidationMessageConfig.INVALID_OFFSET,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileViewService, never()).getFollowers(eq(username), any(Pageable.class));
+    }
+
+    @Test
+    void ProfileViewController_GetFollowers_Throw400InvalidRequest_InvalidLimit() throws Exception {
+        // api: GET /api/v1/profile/{username}/followers ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
+        String username = "existing-user";
+        int offset = 0;
+        int limit = 0;
+
+        String response = mockMvc
+            .perform(get(path, username)
+                .param("offset", String.valueOf(offset))
+                .param("limit", String.valueOf(limit)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.BadRequest.INVALID_REQUEST,
+            ValidationMessageConfig.INVALID_LIMIT,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileViewService, never()).getFollowers(eq(username), any(Pageable.class));
     }
 
     @Test
@@ -276,8 +339,8 @@ class ProfileViewControllerTest {
 
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
+        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
     }
 
     @Test
@@ -310,10 +373,10 @@ class ProfileViewControllerTest {
             new TypeReference<PageDTO<SimplifiedProfileDTO>>() {
             });
 
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
         assertEquals(1, actual.total());
         assertEquals(1, actual.items().size());
+        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
     }
 
     @Test
@@ -344,10 +407,70 @@ class ProfileViewControllerTest {
         PageDTO<ProfileDTO> actual = objectMapper.readValue(response, new TypeReference<PageDTO<ProfileDTO>>() {
         });
 
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
         assertEquals(0, actual.total());
         assertEquals(0, actual.items().size());
+        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
+    }
+
+    @Test
+    void ProfileViewController_GetFollowing_Throw400InvalidRequest_InvalidOffset() throws Exception {
+        // api: GET /api/v1/profile/{username}/following ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
+        String username = "existing-user";
+        int offset = -1;
+        int limit = 1;
+
+        String response = mockMvc
+            .perform(get(path, username)
+                .param("offset", String.valueOf(offset))
+                .param("limit", String.valueOf(limit)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.BadRequest.INVALID_REQUEST,
+            ValidationMessageConfig.INVALID_OFFSET,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileViewService, never()).getFollowing(eq(username), any(Pageable.class));
+    }
+
+    @Test
+    void ProfileViewController_GetFollowing_Throw400InvalidRequest_InvalidLimit() throws Exception {
+        // api: GET /api/v1/profile/{username}/following ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
+        String username = "existing-user";
+        int offset = 0;
+        int limit = 0;
+
+        String response = mockMvc
+            .perform(get(path, username)
+                .param("offset", String.valueOf(offset))
+                .param("limit", String.valueOf(limit)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        ErrorDTO expected = new ErrorDTO(
+            HttpStatus.BAD_REQUEST,
+            ErrorMessageConfig.BadRequest.INVALID_REQUEST,
+            ValidationMessageConfig.INVALID_LIMIT,
+            path);
+
+        ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
+
+        assertEquals(expected, actual);
+        verify(profileViewService, never()).getFollowing(eq(username), any(Pageable.class));
     }
 
     @Test
@@ -379,8 +502,8 @@ class ProfileViewControllerTest {
 
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
         assertEquals(expected, actual);
+        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/validation/ValidationSequenceTest.java
+++ b/src/test/java/com/example/echo_api/unit/validation/ValidationSequenceTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import com.example.echo_api.config.ValidationMessageConfig;
 import com.example.echo_api.validation.account.annotations.Password;
 import com.example.echo_api.validation.account.annotations.Username;
-import com.example.echo_api.validation.sequence.AdvancedCheck;
-import com.example.echo_api.validation.sequence.BasicCheck;
-import com.example.echo_api.validation.sequence.ValidationOrder;
+import com.example.echo_api.validation.sequence.Advanced;
+import com.example.echo_api.validation.sequence.Basic;
+import com.example.echo_api.validation.sequence.ValidationSequence;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -26,12 +26,12 @@ class ValidationSequenceTest {
     // dummy class for validation
     static class TestUser {
 
-        @NotNull(message = "Username is required.", groups = BasicCheck.class)
-        @Username(groups = AdvancedCheck.class)
+        @NotNull(message = "Username is required.", groups = Basic.class)
+        @Username(groups = Advanced.class)
         private String username;
 
-        @NotNull(message = "Password is required.", groups = BasicCheck.class)
-        @Password(groups = AdvancedCheck.class)
+        @NotNull(message = "Password is required.", groups = Basic.class)
+        @Password(groups = Advanced.class)
         private String password;
 
         public TestUser(String username, String password) {
@@ -55,7 +55,7 @@ class ValidationSequenceTest {
             null,
             "invalid-password");
 
-        Set<ConstraintViolation<TestUser>> violations = validator.validate(invalidUser, ValidationOrder.class);
+        Set<ConstraintViolation<TestUser>> violations = validator.validate(invalidUser, ValidationSequence.class);
         assertEquals(1, violations.size()); // fails on null username
 
         ConstraintViolation<TestUser> violation = violations.iterator().next();
@@ -69,7 +69,7 @@ class ValidationSequenceTest {
             "valid_username",
             "invalid-password");
 
-        Set<ConstraintViolation<TestUser>> violations = validator.validate(invalidUser, ValidationOrder.class);
+        Set<ConstraintViolation<TestUser>> violations = validator.validate(invalidUser, ValidationSequence.class);
         assertEquals(1, violations.size()); // fails on invalid password
 
         ConstraintViolation<TestUser> violation = violations.iterator().next();


### PR DESCRIPTION
## Purpose
PR introduces a fix to ensure that pagination validation (offset and limit values) is correctly executed when pinging a paginated API endpoint.

## Changelog
### Controllers
- Removed `@Validated(ValidationSequence.class)` annotations from controllers where a sequence is not necessary

### Util
- Renamed `ValidationOrder` to `ValidationSequence`
- Renamed `BasicCheck` to `Basic`
- Renamed `AdvancedCheck` to `Advanced`

### Testing
- Added unit tests for `offset` and `limit` validation on paginated endpoints