### PR TITLE
refactor: profile interaction endpoints

### DIFF
--- a/src/main/java/com/example/echo_api/config/ApiConfig.java
+++ b/src/main/java/com/example/echo_api/config/ApiConfig.java
@@ -36,10 +36,10 @@ public final class ApiConfig {
         public static final String ME_AVATAR = ROOT + "/me/avatar"; // TODO: consolidate into single PUT to /me
         public static final String ME_BANNER = ROOT + "/me/banner"; // TODO: consolidate into single PUT to /me
         public static final String GET_BY_USERNAME = ROOT + "/{username}";
-        public static final String GET_FOLLOWERS_BY_USERNAME = ROOT + "/{username}/followers"; // TODO: migrate to {id}
-        public static final String GET_FOLLOWING_BY_USERNAME = ROOT + "/{username}/following"; // TODO: migrate to {id}
-        public static final String FOLLOW_BY_USERNAME = ROOT + "/{username}/follow"; // TODO: migrate to {id}
-        public static final String BLOCK_BY_USERNAME = ROOT + "/{username}/block"; // TODO: migrate to {id}
+        public static final String GET_FOLLOWERS_BY_ID = ROOT + "/{id}/followers";
+        public static final String GET_FOLLOWING_BY_ID = ROOT + "/{id}/following";
+        public static final String FOLLOW_BY_ID = ROOT + "/{id}/follow";
+        public static final String BLOCK_BY_ID = ROOT + "/{id}/block";
     }
 
     @NoArgsConstructor(access = PRIVATE)

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileInteractionController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileInteractionController.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.controller.profile;
 
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,27 +19,27 @@ public class ProfileInteractionController {
 
     private final ProfileInteractionService profileInteractionService;
 
-    @PostMapping(ApiConfig.Profile.FOLLOW_BY_USERNAME)
-    public ResponseEntity<Void> followByUsername(@PathVariable("username") String username) {
-        profileInteractionService.follow(username);
+    @PostMapping(ApiConfig.Profile.FOLLOW_BY_ID)
+    public ResponseEntity<Void> followById(@PathVariable("id") UUID id) {
+        profileInteractionService.follow(id);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping(ApiConfig.Profile.FOLLOW_BY_USERNAME)
-    public ResponseEntity<Void> unfollowByUsername(@PathVariable("username") String username) {
-        profileInteractionService.unfollow(username);
+    @DeleteMapping(ApiConfig.Profile.FOLLOW_BY_ID)
+    public ResponseEntity<Void> unfollowById(@PathVariable("id") UUID id) {
+        profileInteractionService.unfollow(id);
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping(ApiConfig.Profile.BLOCK_BY_USERNAME)
-    public ResponseEntity<Void> blockByUsername(@PathVariable("username") String username) {
-        profileInteractionService.block(username);
+    @PostMapping(ApiConfig.Profile.BLOCK_BY_ID)
+    public ResponseEntity<Void> blockById(@PathVariable("id") UUID id) {
+        profileInteractionService.block(id);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping(ApiConfig.Profile.BLOCK_BY_USERNAME)
-    public ResponseEntity<Void> unblockByUsername(@PathVariable("username") String username) {
-        profileInteractionService.unblock(username);
+    @DeleteMapping(ApiConfig.Profile.BLOCK_BY_ID)
+    public ResponseEntity<Void> unblockById(@PathVariable("id") UUID id) {
+        profileInteractionService.unblock(id);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/echo_api/controller/profile/ProfileViewController.java
+++ b/src/main/java/com/example/echo_api/controller/profile/ProfileViewController.java
@@ -1,5 +1,7 @@
 package com.example.echo_api.controller.profile;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -28,7 +30,7 @@ public class ProfileViewController {
 
     @GetMapping(ApiConfig.Profile.ME)
     public ResponseEntity<ProfileDTO> getMe() {
-        return ResponseEntity.ok(profileViewService.getSelf());
+        return ResponseEntity.ok(profileViewService.getMe());
     }
 
     @GetMapping(ApiConfig.Profile.GET_BY_USERNAME)
@@ -37,24 +39,24 @@ public class ProfileViewController {
     }
 
     // @formatter:off
-    @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME)
+    @GetMapping(ApiConfig.Profile.GET_FOLLOWERS_BY_ID)
     public ResponseEntity<PageDTO<SimplifiedProfileDTO>> getFollowers(
-        @PathVariable("username") String username,
+        @PathVariable("id") UUID id,
         @RequestParam(name = "offset", defaultValue = "0") @Offset int offset,
         @RequestParam(name = "limit", defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
-        return ResponseEntity.ok(profileViewService.getFollowers(username, page));
+        return ResponseEntity.ok(profileViewService.getFollowers(id, page));
     }
 
-    @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME)
+    @GetMapping(ApiConfig.Profile.GET_FOLLOWING_BY_ID)
     public ResponseEntity<PageDTO<SimplifiedProfileDTO>> getFollowing(
-        @PathVariable("username") String username,
+       @PathVariable("id") UUID id,
         @RequestParam(name = "offset", defaultValue = "0") @Offset int offset,
         @RequestParam(name = "limit", defaultValue = "20") @Limit int limit
     ) {
         Pageable page = new OffsetLimitRequest(offset, limit);
-        return ResponseEntity.ok(profileViewService.getFollowing(username, page));
+        return ResponseEntity.ok(profileViewService.getFollowing(id, page));
     }
     // @formatter:on
 

--- a/src/main/java/com/example/echo_api/service/profile/interaction/ProfileInteractionService.java
+++ b/src/main/java/com/example/echo_api/service/profile/interaction/ProfileInteractionService.java
@@ -1,47 +1,49 @@
 package com.example.echo_api.service.profile.interaction;
 
+import java.util.UUID;
+
 import com.example.echo_api.exception.custom.notfound.ResourceNotFoundException;
 
 public interface ProfileInteractionService {
 
     /**
-     * Follows a profile by {@code username}.
+     * Follows a profile by {@code id}.
      * 
-     * @param username The username of the profile.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @param id The id of the profile.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      * @throws SelfActionException       If attempting to follow self.
      * @throws BlockedException          if a block exists between the authenticated
      *                                   user and the target profile.
      * @throws AlreadyFollowingException If already following the target profile.
      */
-    public void follow(String username);
+    public void follow(UUID id);
 
     /**
-     * Unfollows a profile by {@code username}.
+     * Unfollows a profile by {@code id}.
      * 
-     * @param username The username of the profile.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @param id The id of the profile.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      * @throws SelfActionException       If attempting to unfollow self.
      */
-    public void unfollow(String username);
+    public void unfollow(UUID id);
 
     /**
-     * Blocks a profile by {@code username}.
+     * Blocks a profile by {@code id}.
      * 
-     * @param username The username of the profile.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @param id The id of the profile.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      * @throws SelfActionException       If attempting to block self.
      * @throws AlreadyBlockingException  If already following the target profile.
      */
-    public void block(String username);
+    public void block(UUID id);
 
     /**
-     * Unblocks a profile by {@code username}.
+     * Unblocks a profile by {@code id}.
      * 
-     * @param username The username of the profile.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @param id The id of the profile.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      * @throws SelfActionException       If attempting to unblock self.
      */
-    public void unblock(String username);
+    public void unblock(UUID id);
 
 }

--- a/src/main/java/com/example/echo_api/service/profile/interaction/ProfileInteractionServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/interaction/ProfileInteractionServiceImpl.java
@@ -43,9 +43,9 @@ public class ProfileInteractionServiceImpl extends BaseProfileService implements
     // @formatter:on
 
     @Override
-    public void follow(String username) {
+    public void follow(UUID id) {
         UUID source = getAuthenticatedUser().getId();
-        UUID target = getProfileEntityByUsername(username).getId();
+        UUID target = getProfileEntityById(id).getId();
 
         validateSelfAction(source, target);
         validateNoBlock(source, target);
@@ -57,18 +57,18 @@ public class ProfileInteractionServiceImpl extends BaseProfileService implements
     }
 
     @Override
-    public void unfollow(String username) {
+    public void unfollow(UUID id) {
         UUID source = getAuthenticatedUser().getId();
-        UUID target = getProfileEntityByUsername(username).getId();
+        UUID target = getProfileEntityById(id).getId();
 
         validateSelfAction(source, target);
         followRepository.deleteByFollowerIdAndFollowedId(source, target);
     }
 
     @Override
-    public void block(String username) {
+    public void block(UUID id) {
         UUID source = getAuthenticatedUser().getId();
-        UUID target = getProfileEntityByUsername(username).getId();
+        UUID target = getProfileEntityById(id).getId();
 
         validateSelfAction(source, target);
         if (blockRepository.existsByBlockerIdAndBlockedId(source, target)) {
@@ -80,9 +80,9 @@ public class ProfileInteractionServiceImpl extends BaseProfileService implements
     }
 
     @Override
-    public void unblock(String username) {
+    public void unblock(UUID id) {
         UUID source = getAuthenticatedUser().getId();
-        UUID target = getProfileEntityByUsername(username).getId();
+        UUID target = getProfileEntityById(id).getId();
 
         validateSelfAction(source, target);
         blockRepository.deleteByBlockerIdAndBlockedId(source, target);

--- a/src/main/java/com/example/echo_api/service/profile/view/ProfileViewService.java
+++ b/src/main/java/com/example/echo_api/service/profile/view/ProfileViewService.java
@@ -16,7 +16,7 @@ public interface ProfileViewService {
      * 
      * @return A {@link ProfileDTO} resembling the users profile.
      */
-    public ProfileDTO getSelf();
+    public ProfileDTO getMe();
 
     /**
      * Fetch a {@link ProfileDTO} by {@code id}.
@@ -38,26 +38,26 @@ public interface ProfileViewService {
 
     /**
      * Fetch a {@link PageDTO} of {@link SimplifiedProfileDTO} for the followers
-     * list of the supplied {@code username} and {@code page} parameters.
+     * list of the supplied {@code id} and {@code page} parameters.
      * 
-     * @param username The username of the profile to query.
-     * @param page     The {@link Pageable} containing the pagination parameters.
+     * @param id   The id of the profile to query.
+     * @param page The {@link Pageable} containing the pagination parameters.
      * @return A {@link PageDTO} of {@link SimplifiedProfileDTO} for matches,
      *         otherwise empty.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      */
-    public PageDTO<SimplifiedProfileDTO> getFollowers(String username, Pageable page) throws ResourceNotFoundException;
+    public PageDTO<SimplifiedProfileDTO> getFollowers(UUID id, Pageable page) throws ResourceNotFoundException;
 
     /**
      * Fetch a {@link PageDTO} of {@link SimplifiedProfileDTO} for the following
-     * list of the supplied {@code username} and {@code page} parameters.
+     * list of the supplied {@code id} and {@code page} parameters.
      * 
-     * @param username The username of the profile to query.
-     * @param page     The {@link Pageable} containing the pagination parameters.
+     * @param id   The id of the profile to query.
+     * @param page The {@link Pageable} containing the pagination parameters.
      * @return A {@link PageDTO} of {@link SimplifiedProfileDTO} for matches,
      *         otherwise empty.
-     * @throws ResourceNotFoundException If no profile by that username exists.
+     * @throws ResourceNotFoundException If no profile by that id exists.
      */
-    public PageDTO<SimplifiedProfileDTO> getFollowing(String username, Pageable page) throws ResourceNotFoundException;
+    public PageDTO<SimplifiedProfileDTO> getFollowing(UUID id, Pageable page) throws ResourceNotFoundException;
 
 }

--- a/src/main/java/com/example/echo_api/service/profile/view/ProfileViewServiceImpl.java
+++ b/src/main/java/com/example/echo_api/service/profile/view/ProfileViewServiceImpl.java
@@ -39,7 +39,7 @@ public class ProfileViewServiceImpl extends BaseProfileService implements Profil
     // @formatter:on
 
     @Override
-    public ProfileDTO getSelf() {
+    public ProfileDTO getMe() {
         UUID authenticatedUserId = getAuthenticatedUser().getId();
 
         return profileRepository.findProfileDtoById(authenticatedUserId, authenticatedUserId)
@@ -63,22 +63,23 @@ public class ProfileViewServiceImpl extends BaseProfileService implements Profil
     }
 
     @Override
-    public PageDTO<SimplifiedProfileDTO> getFollowers(String username, Pageable page) throws ResourceNotFoundException {
-        UUID id = getProfileEntityByUsername(username).getId(); // validate existence of username & convert to id
+    public PageDTO<SimplifiedProfileDTO> getFollowers(UUID id, Pageable page) throws ResourceNotFoundException {
+        UUID profileId = getProfileEntityById(id).getId(); // validate existence of id
         UUID authenticatedUserId = getAuthenticatedUser().getId();
 
-        Page<SimplifiedProfileDTO> query = profileRepository.findFollowerDtosById(id, authenticatedUserId, page);
+        Page<SimplifiedProfileDTO> query = profileRepository.findFollowerDtosById(profileId, authenticatedUserId, page);
         String uri = getCurrentRequestUri();
 
         return PageMapper.toDTO(query, uri);
     }
 
     @Override
-    public PageDTO<SimplifiedProfileDTO> getFollowing(String username, Pageable page) throws ResourceNotFoundException {
-        UUID id = getProfileEntityByUsername(username).getId(); // validate existence of username & convert to id
+    public PageDTO<SimplifiedProfileDTO> getFollowing(UUID id, Pageable page) throws ResourceNotFoundException {
+        UUID profileId = getProfileEntityById(id).getId(); // validate existence of id
         UUID authenticatedUserId = getAuthenticatedUser().getId();
 
-        Page<SimplifiedProfileDTO> query = profileRepository.findFollowingDtosById(id, authenticatedUserId, page);
+        Page<SimplifiedProfileDTO> query = profileRepository.findFollowingDtosById(profileId, authenticatedUserId,
+            page);
         String uri = getCurrentRequestUri();
 
         return PageMapper.toDTO(query, uri);

--- a/src/test/java/com/example/echo_api/integration/controller/ProfileInteractionControllerIT.java
+++ b/src/test/java/com/example/echo_api/integration/controller/ProfileInteractionControllerIT.java
@@ -2,6 +2,9 @@ package com.example.echo_api.integration.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpStatus.*;
+
+import java.util.UUID;
+
 import static org.springframework.http.HttpMethod.*;
 
 import org.junit.jupiter.api.Test;
@@ -26,11 +29,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Follow_Return204NoContent() {
-        // api: POST /api/v1/profile/{username}/follow ==> 204 : No Content
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: POST /api/v1/profile/{id}/follow ==> 204 : No Content
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = otherUser.getId();
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, response.getStatusCode());
@@ -39,11 +42,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Follow_Throw404ResourceNotFound() {
-        // api: POST /api/v1/profile/{username}/follow ==> 404 : ResourceNotFound
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: POST /api/v1/profile/{id}/follow ==> 404 : ResourceNotFound
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());
@@ -58,11 +61,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Follow_Throw409SelfActionException() {
-        // api: POST /api/v1/profile/{username}/follow ==> 409 : SelfAction
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = authenticatedUser.getUsername();
+        // api: POST /api/v1/profile/{id}/follow ==> 409 : SelfAction
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = authenticatedUser.getId();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response.getStatusCode());
@@ -78,19 +81,19 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Follow_Throw409AlreadyFollowingException() {
-        // api: POST /api/v1/profile/{username}/follow ==> 409 : AlreadyFollowing
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: POST /api/v1/profile/{id}/follow ==> 409 : AlreadyFollowing
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = otherUser.getId();
 
         // follow the user to create a follow relationship in the db
-        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, response1.getStatusCode());
         assertNull(response1.getBody());
 
         // attempt to follow the same user again to force a 409 AlreadyFollowing
-        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response2.getStatusCode());
@@ -106,19 +109,19 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Unfollow_Return204NoContent() {
-        // api: DELETE /api/v1/profile/{username}/follow ==> 204 : No Content
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: DELETE /api/v1/profile/{id}/follow ==> 204 : No Content
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = otherUser.getId();
 
         // follow the user to create a follow relationship in the db
-        ResponseEntity<Void> followResponse = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> followResponse = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, followResponse.getStatusCode());
         assertNull(followResponse.getBody());
 
         // unfollow the user
-        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(path, DELETE, null, Void.class, username);
+        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(path, DELETE, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, unfollowResponse.getStatusCode());
@@ -127,11 +130,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Unfollow_Throw404ResourceNotFound() {
-        // api: DELETE /api/v1/profile/{username}/follow ==> 404 : ResourceNotFound
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: DELETE /api/v1/profile/{id}/follow ==> 404 : ResourceNotFound
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());
@@ -146,11 +149,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Unfollow_Throw409SelfActionException() {
-        // api: DELETE /api/v1/profile/{username}/follow ==> 409 : SelfAction
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String username = authenticatedUser.getUsername();
+        // api: DELETE /api/v1/profile/{id}/follow ==> 409 : SelfAction
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
+        UUID id = authenticatedUser.getId();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response.getStatusCode());
@@ -166,11 +169,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Block_Return204NoContent() {
-        // api: POST /api/v1/profile/{username}/block ==> 204 : No Content
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: POST /api/v1/profile/{id}/block ==> 204 : No Content
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = otherUser.getId();
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> response = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, response.getStatusCode());
@@ -179,11 +182,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Block_Throw404ResourceNotFound() {
-        // api: POST /api/v1/profile/{username}/block ==> 404 : ResourceNotFound
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: POST /api/v1/profile/{id}/block ==> 404 : ResourceNotFound
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());
@@ -198,11 +201,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Block_Throw409SelfActionException() {
-        // api: POST /api/v1/profile/{username}/block ==> 400 : SelfAction
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = authenticatedUser.getUsername();
+        // api: POST /api/v1/profile/{id}/block ==> 400 : SelfAction
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = authenticatedUser.getId();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response.getStatusCode());
@@ -218,19 +221,19 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Block_Throw409AlreadyBlockingException() {
-        // api: POST /api/v1/profile/{username}/block ==> 409 : AlreadyBlocking
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: POST /api/v1/profile/{id}/block ==> 409 : AlreadyBlocking
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = otherUser.getId();
 
         // block the user to create a block relationship in the db
-        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, response1.getStatusCode());
         assertNull(response1.getBody());
 
         // attempt to block the same user again to force a 409 AlreadyBlocking
-        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response2 = restTemplate.postForEntity(path, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response2.getStatusCode());
@@ -247,19 +250,19 @@ class ProfileInteractionControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_Unblock_Return204NoContent() {
-        // api: DELETE /api/v1/profile/{username}/block ==> 204 : No Content
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: DELETE /api/v1/profile/{id}/block ==> 204 : No Content
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = otherUser.getId();
 
         // block the user to create a block relationship in the db
-        ResponseEntity<Void> followResponse = restTemplate.postForEntity(path, null, Void.class, username);
+        ResponseEntity<Void> followResponse = restTemplate.postForEntity(path, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, followResponse.getStatusCode());
         assertNull(followResponse.getBody());
 
         // unblock the user
-        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(path, DELETE, null, Void.class, username);
+        ResponseEntity<Void> unfollowResponse = restTemplate.exchange(path, DELETE, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, unfollowResponse.getStatusCode());
@@ -269,11 +272,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Unblock_Throw404ResourceNotFound() {
-        // api: DELETE /api/v1/profile/{username}/block ==> 404 : ResourceNotFound
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: DELETE /api/v1/profile/{id}/block ==> 404 : ResourceNotFound
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());
@@ -288,11 +291,11 @@ class ProfileInteractionControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_Unblock_Throw409SelfActionException() {
-        // api: DELETE /api/v1/profile/{username}/block ==> 409 : SelfAction
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
-        String username = authenticatedUser.getUsername();
+        // api: DELETE /api/v1/profile/{id}/block ==> 409 : SelfAction
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
+        UUID id = authenticatedUser.getId();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, DELETE, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(CONFLICT, response.getStatusCode());

--- a/src/test/java/com/example/echo_api/integration/controller/ProfileViewControllerIT.java
+++ b/src/test/java/com/example/echo_api/integration/controller/ProfileViewControllerIT.java
@@ -2,6 +2,9 @@ package com.example.echo_api.integration.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpStatus.*;
+
+import java.util.UUID;
+
 import static org.springframework.http.HttpMethod.*;
 
 import org.junit.jupiter.api.Test;
@@ -82,13 +85,13 @@ class ProfileViewControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_GetFollowers_Return200PageOfProfileDTO() {
-        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
-        String followPath = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String getFollowersPath = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME + "?offset=0&limit=1";
-        String username = otherUser.getUsername();
+        // api: GET /api/v1/profile/{id}/followers ==> 200 : PageDTO<ProfileDTO>
+        String followPath = ApiConfig.Profile.FOLLOW_BY_ID;
+        String getFollowersPath = ApiConfig.Profile.GET_FOLLOWERS_BY_ID + "?offset=0&limit=1";
+        UUID id = otherUser.getId();
 
         // follow target user to create a follow relationship in the db
-        ResponseEntity<Void> response1 = restTemplate.postForEntity(followPath, null, Void.class, username);
+        ResponseEntity<Void> response1 = restTemplate.postForEntity(followPath, null, Void.class, id);
 
         // assert response
         assertEquals(NO_CONTENT, response1.getStatusCode());
@@ -97,8 +100,7 @@ class ProfileViewControllerIT extends IntegrationTest {
         // get followers of target user
         ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
         };
-        ResponseEntity<PageDTO<ProfileDTO>> response2 = restTemplate.exchange(getFollowersPath, GET, null, typeRef,
-            username);
+        ResponseEntity<PageDTO<ProfileDTO>> response2 = restTemplate.exchange(getFollowersPath, GET, null, typeRef, id);
 
         // assert response
         assertEquals(OK, response2.getStatusCode());
@@ -115,13 +117,13 @@ class ProfileViewControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_GetFollowers_Return200PageOfEmpty() {
-        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: GET /api/v1/profile/{id}/followers ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = otherUser.getId();
 
         ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
         };
-        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, username);
+        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, id);
 
         // assert response
         assertEquals(OK, response.getStatusCode());
@@ -137,11 +139,11 @@ class ProfileViewControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_GetFollowers_Throw404ResourceNotFound() {
-        // api: GET /api/v1/profile/{username}/followers ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 404 : Resource Not Found
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());
@@ -157,15 +159,14 @@ class ProfileViewControllerIT extends IntegrationTest {
     @Test
     @Sql(scripts = "/sql/profile-interaction-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void ProfileController_GetFollowing_Return200PageOfProfileDTO() {
-        // api: GET /api/v1/profile/{username}/following ==> 400 : PageDTO<ProfileDTO>
-        String followPath = ApiConfig.Profile.FOLLOW_BY_USERNAME;
-        String getFollowingPath = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME + "?offset=0&limit=1";
-        String followUsername = otherUser.getUsername();
-        String getFollowingUsername = authenticatedUser.getUsername();
+        // api: GET /api/v1/profile/{id}/following ==> 400 : PageDTO<ProfileDTO>
+        String followPath = ApiConfig.Profile.FOLLOW_BY_ID;
+        String getFollowingPath = ApiConfig.Profile.GET_FOLLOWING_BY_ID + "?offset=0&limit=1";
+        UUID followId = otherUser.getId();
+        UUID getFollowingId = authenticatedUser.getId();
 
         // follow target user to create a follow relationship in the db
-        ResponseEntity<ErrorDTO> response1 = restTemplate.postForEntity(followPath, null, ErrorDTO.class,
-            followUsername);
+        ResponseEntity<ErrorDTO> response1 = restTemplate.postForEntity(followPath, null, ErrorDTO.class, followId);
 
         System.out.println("-----------------------");
         System.out.println(response1.getBody());
@@ -179,7 +180,7 @@ class ProfileViewControllerIT extends IntegrationTest {
         ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
         };
         ResponseEntity<PageDTO<ProfileDTO>> response2 = restTemplate.exchange(getFollowingPath, GET, null, typeRef,
-            getFollowingUsername);
+            getFollowingId);
 
         // assert response
         assertEquals(OK, response2.getStatusCode());
@@ -191,18 +192,18 @@ class ProfileViewControllerIT extends IntegrationTest {
         assertNull(data.next());
         assertEquals(1, data.total());
         assertEquals(1, data.items().size());
-        assertEquals(followUsername, data.items().get(0).username());
+        assertEquals(followId.toString(), data.items().get(0).id());
     }
 
     @Test
     void ProfileController_GetFollowing_Return200PageOfEmpty() {
-        // api: GET /api/v1/profile/{username}/following ==> 400 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = otherUser.getUsername();
+        // api: GET /api/v1/profile/{id}/following ==> 400 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = otherUser.getId();
 
         ParameterizedTypeReference<PageDTO<ProfileDTO>> typeRef = new ParameterizedTypeReference<PageDTO<ProfileDTO>>() {
         };
-        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, username);
+        ResponseEntity<PageDTO<ProfileDTO>> response = restTemplate.exchange(path, GET, null, typeRef, id);
 
         // assert response
         assertEquals(OK, response.getStatusCode());
@@ -218,11 +219,11 @@ class ProfileViewControllerIT extends IntegrationTest {
 
     @Test
     void ProfileController_GetFollowing_Throw404ResourceNotFound() {
-        // api: GET /api/v1/profile/{username}/following ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: GET /api/v1/profile/{id}/following ==> 404 : Resource Not Found
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
 
-        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, username);
+        ResponseEntity<ErrorDTO> response = restTemplate.exchange(path, GET, null, ErrorDTO.class, id);
 
         // assert response
         assertEquals(NOT_FOUND, response.getStatusCode());

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileInteractionControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileInteractionControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -47,29 +49,29 @@ class ProfileInteractionControllerTest {
     @Test
     void ProfileInteractionController_Follow_Return204NoContent() throws Exception {
         // api: POST /api/v1/profile/{username}/follow ==> 204 : No Content
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doNothing().when(profileInteractionService).follow(username);
+        UUID id = UUID.randomUUID();
+        doNothing().when(profileInteractionService).follow(id);
 
         mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isNoContent());
 
-        verify(profileInteractionService, times(1)).follow(username);
+        verify(profileInteractionService, times(1)).follow(id);
     }
 
     @Test
     void ProfileInteractionController_Follow_Throw404ResouceNotFound() throws Exception {
         // api: POST /api/v1/profile/{username}/follow ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new ResourceNotFoundException()).when(profileInteractionService).follow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new ResourceNotFoundException()).when(profileInteractionService).follow(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isNotFound())
             .andReturn()
@@ -85,20 +87,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).follow(username);
+        verify(profileInteractionService, times(1)).follow(id);
     }
 
     @Test
     void ProfileInteractionController_Follow_Throw409SelfActionException() throws Exception {
         // api: POST /api/v1/profile/{username}/follow ==> 409 : Self Action
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new SelfActionException()).when(profileInteractionService)
-            .follow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new SelfActionException()).when(profileInteractionService).follow(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -114,19 +115,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).follow(username);
+        verify(profileInteractionService, times(1)).follow(id);
     }
 
     @Test
     void ProfileInteractionController_Follow_Throw409AlreadyFollowingException() throws Exception {
         // api: POST /api/v1/profile/{username}/follow ==> 409 : AlreadyFollowing
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new AlreadyFollowingException()).when(profileInteractionService).follow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new AlreadyFollowingException()).when(profileInteractionService).follow(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -142,19 +143,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).follow(username);
+        verify(profileInteractionService, times(1)).follow(id);
     }
 
     @Test
     void ProfileInteractionController_Follow_Throw403BlockedException() throws Exception {
         // api: POST /api/v1/profile/{username}/follow ==> 403 : Blocked
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new BlockedException()).when(profileInteractionService).follow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new BlockedException()).when(profileInteractionService).follow(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isForbidden())
             .andReturn()
@@ -170,35 +171,35 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).follow(username);
+        verify(profileInteractionService, times(1)).follow(id);
     }
 
     @Test
     void ProfileInteractionController_Unfollow_Return204NoContent() throws Exception {
         // api: DELETE /api/v1/profile/{username}/follow ==> 204 : No Content
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doNothing().when(profileInteractionService).unfollow("username");
+        UUID id = UUID.randomUUID();
+        doNothing().when(profileInteractionService).unfollow(id);
 
         mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isNoContent());
 
-        verify(profileInteractionService, times(1)).unfollow(username);
+        verify(profileInteractionService, times(1)).unfollow(id);
     }
 
     @Test
     void ProfileInteractionController_Unfollow_Throw404ResouceNotFound() throws Exception {
         // api: DELETE /api/v1/profile/{username}/follow ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new ResourceNotFoundException()).when(profileInteractionService).unfollow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new ResourceNotFoundException()).when(profileInteractionService).unfollow(id);
 
         String response = mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isNotFound())
             .andReturn()
@@ -214,20 +215,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).unfollow(username);
+        verify(profileInteractionService, times(1)).unfollow(id);
     }
 
     @Test
     void ProfileInteractionController_Unfollow_Throw409SelfActionException() throws Exception {
         // api: DELETE /api/v1/profile/{username}/follow ==> 409 : Self Action
-        String path = ApiConfig.Profile.FOLLOW_BY_USERNAME;
+        String path = ApiConfig.Profile.FOLLOW_BY_ID;
 
-        String username = "username";
-        doThrow(new SelfActionException()).when(profileInteractionService)
-            .unfollow("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new SelfActionException()).when(profileInteractionService).unfollow(id);
 
         String response = mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -243,35 +243,35 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).unfollow(username);
+        verify(profileInteractionService, times(1)).unfollow(id);
     }
 
     @Test
     void ProfileInteractionController_Block_Return204NoContent() throws Exception {
         // api: POST /api/v1/profile/{username}/block ==> 204 : No Content
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doNothing().when(profileInteractionService).block("username");
+        UUID id = UUID.randomUUID();
+        doNothing().when(profileInteractionService).block(id);
 
         mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isNoContent());
 
-        verify(profileInteractionService, times(1)).block(username);
+        verify(profileInteractionService, times(1)).block(id);
     }
 
     @Test
     void ProfileInteractionController_Block_Throw404ResouceNotFound() throws Exception {
         // api: POST /api/v1/profile/{username}/block ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doThrow(new ResourceNotFoundException()).when(profileInteractionService).block("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new ResourceNotFoundException()).when(profileInteractionService).block(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isNotFound())
             .andReturn()
@@ -287,20 +287,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).block(username);
+        verify(profileInteractionService, times(1)).block(id);
     }
 
     @Test
     void ProfileInteractionController_Block_Throw409SelfActionException() throws Exception {
         // api: POST /api/v1/profile/{username}/block ==> 409 : Self Action
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doThrow(new SelfActionException()).when(profileInteractionService)
-            .block("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new SelfActionException()).when(profileInteractionService).block(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -316,19 +315,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).block(username);
+        verify(profileInteractionService, times(1)).block(id);
     }
 
     @Test
     void ProfileInteractionController_Block_Throw409AlreadyBlockingException() throws Exception {
         // api: POST /api/v1/profile/{username}/block ==> 409 : AlreadyBlocking
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doThrow(new AlreadyBlockingException()).when(profileInteractionService).block("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new AlreadyBlockingException()).when(profileInteractionService).block(id);
 
         String response = mockMvc
-            .perform(post(path, username))
+            .perform(post(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -344,35 +343,35 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).block(username);
+        verify(profileInteractionService, times(1)).block(id);
     }
 
     @Test
     void ProfileInteractionController_Unblock_Return204NoContent() throws Exception {
         // api: DELETE /api/v1/profile/{username}/block ==> 204 : No Content
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doNothing().when(profileInteractionService).unblock("username");
+        UUID id = UUID.randomUUID();
+        doNothing().when(profileInteractionService).unblock(id);
 
         mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isNoContent());
 
-        verify(profileInteractionService, times(1)).unblock(username);
+        verify(profileInteractionService, times(1)).unblock(id);
     }
 
     @Test
     void ProfileInteractionController_Unblock_Throw404ResouceNotFound() throws Exception {
         // api: DELETE /api/v1/profile/{username}/block ==> 404 : ResourceNotFound
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doThrow(new ResourceNotFoundException()).when(profileInteractionService).unblock("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new ResourceNotFoundException()).when(profileInteractionService).unblock(id);
 
         String response = mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isNotFound())
             .andReturn()
@@ -388,20 +387,19 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).unblock(username);
+        verify(profileInteractionService, times(1)).unblock(id);
     }
 
     @Test
     void ProfileInteractionController_Unblock_Throw409SelfActionException() throws Exception {
         // api: DELETE /api/v1/profile/{username}/block ==> 409 : SelfAction
-        String path = ApiConfig.Profile.BLOCK_BY_USERNAME;
+        String path = ApiConfig.Profile.BLOCK_BY_ID;
 
-        String username = "username";
-        doThrow(new SelfActionException()).when(profileInteractionService)
-            .unblock("username");
+        UUID id = UUID.randomUUID();
+        doThrow(new SelfActionException()).when(profileInteractionService).unblock(id);
 
         String response = mockMvc
-            .perform(delete(path, username))
+            .perform(delete(path, id))
             .andDo(print())
             .andExpect(status().isConflict())
             .andReturn()
@@ -417,7 +415,7 @@ class ProfileInteractionControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileInteractionService, times(1)).unblock(username);
+        verify(profileInteractionService, times(1)).unblock(id);
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/controller/ProfileViewControllerTest.java
+++ b/src/test/java/com/example/echo_api/unit/controller/ProfileViewControllerTest.java
@@ -85,7 +85,7 @@ class ProfileViewControllerTest {
 
         ProfileDTO expected = createProfileDto(UUID.randomUUID(), "test");
 
-        when(profileViewService.getSelf()).thenReturn(expected);
+        when(profileViewService.getMe()).thenReturn(expected);
 
         String response = mockMvc
             .perform(get(path))
@@ -98,7 +98,7 @@ class ProfileViewControllerTest {
         ProfileDTO actual = objectMapper.readValue(response, ProfileDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, times(1)).getSelf();
+        verify(profileViewService, times(1)).getMe();
     }
 
     @Test
@@ -106,7 +106,7 @@ class ProfileViewControllerTest {
         // api: GET /api/v1/profile/me ==> 404 : Resource Not Found
         String path = ApiConfig.Profile.ME;
 
-        when(profileViewService.getSelf()).thenThrow(new ResourceNotFoundException());
+        when(profileViewService.getMe()).thenThrow(new ResourceNotFoundException());
 
         String response = mockMvc
             .perform(get(path))
@@ -125,7 +125,7 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, times(1)).getSelf();
+        verify(profileViewService, times(1)).getMe();
     }
 
     @Test
@@ -182,22 +182,22 @@ class ProfileViewControllerTest {
 
     @Test
     void ProfileViewController_GetFollowers_Return200PageOfProfileDTO() throws Exception {
-        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
         Pageable page = new OffsetLimitRequest(offset, limit);
 
-        SimplifiedProfileDTO profileDto = createSimplifiedProfileDto(UUID.randomUUID(), username);
+        SimplifiedProfileDTO profileDto = createSimplifiedProfileDto(id, "username");
         Page<SimplifiedProfileDTO> pageProfileDto = new PageImpl<>(List.of(profileDto), page, 1);
         PageDTO<SimplifiedProfileDTO> expected = PageMapper.toDTO(pageProfileDto, path);
 
-        when(profileViewService.getFollowers(eq(username), any(Pageable.class))).thenReturn(expected);
+        when(profileViewService.getFollowers(eq(id), any(Pageable.class))).thenReturn(expected);
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -213,14 +213,14 @@ class ProfileViewControllerTest {
         assertEquals(expected, actual);
         assertEquals(1, actual.total());
         assertEquals(1, actual.items().size());
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowers(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowers_Return200PageOfEmpty() throws Exception {
-        // api: GET /api/v1/profile/{username}/followers ==> 200 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
@@ -229,10 +229,10 @@ class ProfileViewControllerTest {
         Page<SimplifiedProfileDTO> pageProfileDto = new PageImpl<>(new ArrayList<>(), page, 0);
         PageDTO<SimplifiedProfileDTO> expected = PageMapper.toDTO(pageProfileDto, path);
 
-        when(profileViewService.getFollowers(eq(username), any(Pageable.class))).thenReturn(expected);
+        when(profileViewService.getFollowers(eq(id), any(Pageable.class))).thenReturn(expected);
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -247,19 +247,19 @@ class ProfileViewControllerTest {
         assertEquals(expected, actual);
         assertEquals(0, actual.total());
         assertEquals(0, actual.items().size());
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowers(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowers_Throw400InvalidRequest_InvalidOffset() throws Exception {
-        // api: GET /api/v1/profile/{username}/followers ==> 400 : InvalidRequest
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = -1;
         int limit = 1;
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -277,19 +277,19 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, never()).getFollowers(eq(username), any(Pageable.class));
+        verify(profileViewService, never()).getFollowers(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowers_Throw400InvalidRequest_InvalidLimit() throws Exception {
-        // api: GET /api/v1/profile/{username}/followers ==> 400 : InvalidRequest
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 0;
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -307,22 +307,22 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, never()).getFollowers(eq(username), any(Pageable.class));
+        verify(profileViewService, never()).getFollowers(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowers_Throw404ResourceNotFound() throws Exception {
-        // api: GET /api/v1/profile/{username}/followers ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: GET /api/v1/profile/{id}/followers ==> 404 : Resource Not Found
+        String path = ApiConfig.Profile.GET_FOLLOWERS_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
-        when(profileViewService.getFollowers(eq(username), any(Pageable.class)))
+        when(profileViewService.getFollowers(eq(id), any(Pageable.class)))
             .thenThrow(new ResourceNotFoundException());
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -340,27 +340,27 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, times(1)).getFollowers(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowers(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowing_Return200PageOfProfileDTO() throws Exception {
-        // api: GET /api/v1/profile/{username}/following ==> 200 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/following ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
         Pageable page = new OffsetLimitRequest(offset, limit);
 
-        SimplifiedProfileDTO profileDto = createSimplifiedProfileDto(UUID.randomUUID(), username);
+        SimplifiedProfileDTO profileDto = createSimplifiedProfileDto(id, "username");
         Page<SimplifiedProfileDTO> pageProfileDto = new PageImpl<>(List.of(profileDto), page, 1);
         PageDTO<SimplifiedProfileDTO> expected = PageMapper.toDTO(pageProfileDto, path);
 
-        when(profileViewService.getFollowing(eq(username), any(Pageable.class))).thenReturn(expected);
+        when(profileViewService.getFollowing(eq(id), any(Pageable.class))).thenReturn(expected);
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -376,14 +376,14 @@ class ProfileViewControllerTest {
         assertEquals(expected, actual);
         assertEquals(1, actual.total());
         assertEquals(1, actual.items().size());
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowing(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowing_Return200PageOfEmpty() throws Exception {
-        // api: GET /api/v1/profile/{username}/following ==> 200 : PageDTO<ProfileDTO>
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/following ==> 200 : PageDTO<ProfileDTO>
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
@@ -392,10 +392,10 @@ class ProfileViewControllerTest {
         Page<SimplifiedProfileDTO> pageProfileDto = new PageImpl<>(new ArrayList<>(), page, 0);
         PageDTO<SimplifiedProfileDTO> expected = PageMapper.toDTO(pageProfileDto, path);
 
-        when(profileViewService.getFollowing(eq(username), any(Pageable.class))).thenReturn(expected);
+        when(profileViewService.getFollowing(eq(id), any(Pageable.class))).thenReturn(expected);
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -410,19 +410,19 @@ class ProfileViewControllerTest {
         assertEquals(expected, actual);
         assertEquals(0, actual.total());
         assertEquals(0, actual.items().size());
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowing(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowing_Throw400InvalidRequest_InvalidOffset() throws Exception {
-        // api: GET /api/v1/profile/{username}/following ==> 400 : InvalidRequest
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/following ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = -1;
         int limit = 1;
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -440,19 +440,19 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, never()).getFollowing(eq(username), any(Pageable.class));
+        verify(profileViewService, never()).getFollowing(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowing_Throw400InvalidRequest_InvalidLimit() throws Exception {
-        // api: GET /api/v1/profile/{username}/following ==> 400 : InvalidRequest
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "existing-user";
+        // api: GET /api/v1/profile/{id}/following ==> 400 : InvalidRequest
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 0;
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -470,22 +470,22 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, never()).getFollowing(eq(username), any(Pageable.class));
+        verify(profileViewService, never()).getFollowing(eq(id), any(Pageable.class));
     }
 
     @Test
     void ProfileViewController_GetFollowing_Throw404ResourceNotFound() throws Exception {
-        // api: GET /api/v1/profile/{username}/following ==> 404 : Resource Not Found
-        String path = ApiConfig.Profile.GET_FOLLOWING_BY_USERNAME;
-        String username = "non-existent-user";
+        // api: GET /api/v1/profile/{id}/following ==> 404 : Resource Not Found
+        String path = ApiConfig.Profile.GET_FOLLOWING_BY_ID;
+        UUID id = UUID.randomUUID();
         int offset = 0;
         int limit = 1;
 
-        when(profileViewService.getFollowing(eq(username), any(Pageable.class)))
+        when(profileViewService.getFollowing(eq(id), any(Pageable.class)))
             .thenThrow(new ResourceNotFoundException());
 
         String response = mockMvc
-            .perform(get(path, username)
+            .perform(get(path, id)
                 .param("offset", String.valueOf(offset))
                 .param("limit", String.valueOf(limit)))
             .andDo(print())
@@ -503,7 +503,7 @@ class ProfileViewControllerTest {
         ErrorDTO actual = objectMapper.readValue(response, ErrorDTO.class);
 
         assertEquals(expected, actual);
-        verify(profileViewService, times(1)).getFollowing(eq(username), any(Pageable.class));
+        verify(profileViewService, times(1)).getFollowing(eq(id), any(Pageable.class));
     }
 
 }

--- a/src/test/java/com/example/echo_api/unit/service/ProfileInteractionServiceTest.java
+++ b/src/test/java/com/example/echo_api/unit/service/ProfileInteractionServiceTest.java
@@ -68,12 +68,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Follow_ReturnVoid() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
-        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), target.getId())).thenReturn(false);
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
+        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), id)).thenReturn(false);
 
         // act & assert
-        assertDoesNotThrow(() -> profileInteractionService.follow(target.getUsername()));
+        assertDoesNotThrow(() -> profileInteractionService.follow(id));
         verify(followRepository, times(1)).save(any(Follow.class));
     }
 
@@ -84,11 +86,13 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Follow_ThrowResourceNotFound() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.empty());
+        when(profileRepository.findById(id)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.follow(target.getUsername()));
+        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.follow(id));
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -100,11 +104,13 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Follow_ThrowSelfActionException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(authenticatedUserProfile));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(authenticatedUserProfile));
 
         // act & assert
-        assertThrows(SelfActionException.class, () -> profileInteractionService.follow(target.getUsername()));
+        assertThrows(SelfActionException.class, () -> profileInteractionService.follow(id));
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -116,12 +122,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Follow_ThrowBlockedException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
-        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), target.getId())).thenReturn(true);
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
+        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), id)).thenReturn(true);
 
         // act & assert
-        assertThrows(BlockedException.class, () -> profileInteractionService.follow(target.getUsername()));
+        assertThrows(BlockedException.class, () -> profileInteractionService.follow(id));
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -133,14 +141,16 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Follow_ThrowAlreadyFollowingException() {
         // arrange
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        UUID id = target.getId();
+
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), target.getId())).thenReturn(false);
-        when(followRepository.existsByFollowerIdAndFollowedId(authenticatedUser.getId(), target.getId()))
+        when(blockRepository.existsAnyBlockBetween(authenticatedUser.getId(), id)).thenReturn(false);
+        when(followRepository.existsByFollowerIdAndFollowedId(authenticatedUser.getId(), id))
             .thenReturn(true);
 
         // act & assert
-        assertThrows(AlreadyFollowingException.class, () -> profileInteractionService.follow(target.getUsername()));
+        assertThrows(AlreadyFollowingException.class, () -> profileInteractionService.follow(id));
         verify(followRepository, times(0)).save(any(Follow.class));
     }
 
@@ -151,12 +161,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unfollow_ReturnVoid() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
 
         // act & assert
-        assertDoesNotThrow(() -> profileInteractionService.unfollow(target.getUsername()));
-        verify(followRepository, times(1)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), target.getId());
+        assertDoesNotThrow(() -> profileInteractionService.unfollow(id));
+        verify(followRepository, times(1)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), id);
     }
 
     /**
@@ -166,12 +178,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unfollow_ThrowResourceNotFound() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.empty());
+        when(profileRepository.findById(id)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.unfollow(target.getUsername()));
-        verify(followRepository, times(0)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), target.getId());
+        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.unfollow(id));
+        verify(followRepository, times(0)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), id);
     }
 
     /**
@@ -182,12 +196,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unfollow_ThrowSelfActionException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(authenticatedUserProfile));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(authenticatedUserProfile));
 
         // act & assert
-        assertThrows(SelfActionException.class, () -> profileInteractionService.unfollow(target.getUsername()));
-        verify(followRepository, times(0)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), target.getId());
+        assertThrows(SelfActionException.class, () -> profileInteractionService.unfollow(id));
+        verify(followRepository, times(0)).deleteByFollowerIdAndFollowedId(authenticatedUser.getId(), id);
     }
 
     /**
@@ -197,13 +213,15 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Block_ReturnVoid() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
-        when(blockRepository.existsByBlockerIdAndBlockedId(authenticatedUser.getId(), target.getId()))
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
+        when(blockRepository.existsByBlockerIdAndBlockedId(authenticatedUser.getId(), id))
             .thenReturn(false);
 
         // act & assert
-        assertDoesNotThrow(() -> profileInteractionService.block(target.getUsername()));
+        assertDoesNotThrow(() -> profileInteractionService.block(id));
         verify(blockRepository, times(1)).save(any(Block.class));
     }
 
@@ -214,11 +232,13 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Block_ThrowResourceNotFound() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.empty());
+        when(profileRepository.findById(id)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.block(target.getUsername()));
+        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.block(id));
         verify(blockRepository, times(0)).save(any(Block.class));
     }
 
@@ -230,11 +250,13 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Block_ThrowSelfActionException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(authenticatedUserProfile));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(authenticatedUserProfile));
 
         // act & assert
-        assertThrows(SelfActionException.class, () -> profileInteractionService.block(target.getUsername()));
+        assertThrows(SelfActionException.class, () -> profileInteractionService.block(id));
         verify(blockRepository, times(0)).save(any(Block.class));
     }
 
@@ -246,12 +268,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Block_ThrowAlreadyBlockingException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
-        when(blockRepository.existsByBlockerIdAndBlockedId(authenticatedUser.getId(), target.getId())).thenReturn(true);
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
+        when(blockRepository.existsByBlockerIdAndBlockedId(authenticatedUser.getId(), id)).thenReturn(true);
 
         // act & assert
-        assertThrows(AlreadyBlockingException.class, () -> profileInteractionService.block(target.getUsername()));
+        assertThrows(AlreadyBlockingException.class, () -> profileInteractionService.block(id));
         verify(blockRepository, times(0)).save(any(Block.class));
     }
 
@@ -262,12 +286,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unblock_ReturnVoid() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(target));
 
         // act & assert
-        assertDoesNotThrow(() -> profileInteractionService.unblock(target.getUsername()));
-        verify(blockRepository, times(1)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), target.getId());
+        assertDoesNotThrow(() -> profileInteractionService.unblock(id));
+        verify(blockRepository, times(1)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), id);
     }
 
     /**
@@ -277,12 +303,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unblock_ThrowResourceNotFound() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.empty());
+        when(profileRepository.findById(id)).thenReturn(Optional.empty());
 
         // act & assert
-        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.unblock(target.getUsername()));
-        verify(blockRepository, times(0)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), target.getId());
+        assertThrows(ResourceNotFoundException.class, () -> profileInteractionService.unblock(id));
+        verify(blockRepository, times(0)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), id);
     }
 
     /**
@@ -293,12 +321,14 @@ class ProfileInteractionServiceTest {
     @Test
     void ProfileInteractionService_Unblock_ThrowSelfActionException() {
         // arrange
+        UUID id = target.getId();
+
         when(sessionService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        when(profileRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(authenticatedUserProfile));
+        when(profileRepository.findById(id)).thenReturn(Optional.of(authenticatedUserProfile));
 
         // act & assert
-        assertThrows(SelfActionException.class, () -> profileInteractionService.unblock(target.getUsername()));
-        verify(blockRepository, times(0)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), target.getId());
+        assertThrows(SelfActionException.class, () -> profileInteractionService.unblock(id));
+        verify(blockRepository, times(0)).deleteByBlockerIdAndBlockedId(authenticatedUser.getId(), id);
     }
 
 }


### PR DESCRIPTION
## Purpose
PR introduces a refactor to some profile-related endpoints by changing the required path variable from a USERNAME to an ID.

- `/api/v1/profile/{username}/follow` updated to `/api/v1/profile/{id}/follow`
- `/api/v1/profile/{username}/block` updated to `/api/v1/profile/{id}/block`
- `/api/v1/profile/{username}/followers` updated to `/api/v1/profile/{id}/followers`
- `/api/v1/profile/{username}/following` updated to `/api/v1/profile/{id}/following`

## Changelog
### Config
- Refactored the above profile-related API endpoints to use `{id}` instead of `{username}`

### Controllers
- Refactored `ProfileViewController` methods `getFollowers` `getFollowing` to consume an ID path variable
- Refactored `ProfileInteractionController` methods `follow` `block` to consume an ID path variable

### Services
- Refactored `ProfileViewService` methods `getFollowers` `getFollowing` to accept `UUID id`
- Refactored `ProfileInteractionService` methods `follow` `unfollow` `block` `unblock` to accept `UUID id`

### Testing
- Refactored affected `ProfileViewControllerIT` integration tests
- Refactored affected `ProfileInteractionControllerIT` integration tests
- Refactored affected `ProfileViewControllerTest` unit tests
- Refactored affected `ProfileInteractionControllerTest` unit tests
- Refactored affected `ProfileViewServiceTest` unit tests
- Refactored affected `ProfileInteractionServiceTest` unit tests